### PR TITLE
Add build of libuv for supporting Kestrel Web Server

### DIFF
--- a/1.0.0-alpha4/Dockerfile
+++ b/1.0.0-alpha4/Dockerfile
@@ -9,4 +9,17 @@ RUN bash -c "source /root/.kre/kvm/kvm.sh \
 	&& kvm install $KRE_VERSION -a default \
 	&& kvm alias default | xargs -i ln -s /root/.kre/packages/{} /root/.kre/packages/default"
 
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.0.0-rc2 \
+	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
 ENV PATH $PATH:/root/.kre/packages/default/bin

--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -9,4 +9,17 @@ RUN bash -c "source /root/.kre/kvm/kvm.sh \
 	&& kvm install $KRE_VERSION -a default \
 	&& kvm alias default | xargs -i ln -s /root/.kre/packages/{} /root/.kre/packages/default"
 
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.0.0-rc2 \
+	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
 ENV PATH $PATH:/root/.kre/packages/default/bin


### PR DESCRIPTION
As Kestrel is supposed to be the major web server backend on ASP.NET for Linux, I wanted to give it a try. So, I added build procedure of libuv to satisfy the dependency.

I created and tested my PR against 1.0.0-beta1.
tested automated build on my fork at Docker Hub: https://registry.hub.docker.com/u/muojp/aspnet-docker/builds_history/82573/ and also tested on derived https://registry.hub.docker.com/u/muojp/hellovnext-docker/ for making sure everything works fine.

For double checking, please try this:

```
$ docker run -p 5000:5000 -di muojp/hellovnext-docker:latest /bin/bash -c "kpm restore && k web"
$ ab -k -n 100 -c 20 http://localhost:5000/
-> ok
$ docker run -p 5000:5000 -di muojp/hellovnext-docker:latest /bin/bash -c "kpm restore && k kestrel"
$ ab -k -n 100 -c 20 http://localhost:5000/
-> ok
```

(Note: I've already signed CLA)
