### PR TITLE
Replace K Runtime install location by $KRE_USER_HOME to avoid troubles

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -1,13 +1,14 @@
 FROM mono:3.10
 
 ENV KRE_VERSION 1.0.0-beta1
+ENV KRE_USER_HOME /opt/kre
 
 RUN apt-get -qq update && apt-get -qqy install unzip
 
 RUN curl -s https://raw.githubusercontent.com/aspnet/Home/v$KRE_VERSION/kvminstall.sh | sh
-RUN bash -c "source /root/.kre/kvm/kvm.sh \
+RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
 	&& kvm install $KRE_VERSION -a default \
-	&& kvm alias default | xargs -i ln -s /root/.kre/packages/{} /root/.kre/packages/default"
+	&& kvm alias default | xargs -i ln -s $KRE_USER_HOME/packages/{} $KRE_USER_HOME/packages/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
 RUN apt-get -qqy install \
@@ -22,4 +23,4 @@ RUN LIBUV_VERSION=1.0.0-rc2 \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
 	&& ldconfig
 
-ENV PATH $PATH:/root/.kre/packages/default/bin
+ENV PATH $PATH:$KRE_USER_HOME/packages/default/bin


### PR DESCRIPTION
On my Ubuntu 14.04 machine, $HOME during `docker build` seem always point "/", but containers built on Docker Hub imply me they point "/root" as their home. This situation sometimes trouble us because KRE install location by default depends on `~`. For example, I have a Docker Hub hosted container derived from official ASP.NET Docker image: https://registry.hub.docker.com/u/muojp/hellovnext-docker/ and its build result shows me $HOME points "/", not "/root" even on Docker Hub. Thus I temporarily put memo to perform redundant `kpm restore` on start-up.

Regarding https://github.com/docker/docker/issues/2968 , this situation would be well handled by setting $HOME env variable or in some other ways.

Because $HOME issue should be separated from k/kpm path issue, it'd be great to set $KRE_USER_HOME for kvminstall.sh to point where KRE root is this time.
ref: install target path specification in kvminstall.sh https://github.com/aspnet/Home/blob/88ec2806623439291c4babeaa5a62eacb5b4189e/kvminstall.sh#L20-L22

This PR is based on $KRE_USER_HOME approach. I already tested the image with: 

```
$ docker run -it muojp/aspnet-docker:fix_kruntime_home_test /bin/bash
# kpm
Usage: kpm [options] [command]
... snip ...
# env
KRE_USER_HOME=/opt/kre
HOSTNAME=512a90802a84
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/kre/packages/default/bin
PWD=/
SHLVL=1
HOME=/
KRE_VERSION=1.0.0-beta1
_=/usr/bin/env
```

As a draft, I set $KRE_USER_HOME => /opt/kre. Comments and enhancement proposals (such as better KRE_USER_HOME path) are welcomed.
