### PR TITLE
Added Dockerfile to download the nightly build of ASP.NET 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains `Dockerfile` definitions for [ASP.NET 5][home] Docker i
 
 * [`latest` _(Dockerfile)_](1.0.0-beta1/Dockerfile)
 * [`1.0.0-beta1` _(Dockerfile)_](1.0.0-beta1/Dockerfile)
+* [`nightly` _(Dockerfile)_](nightly/Dockerfile)
 
 This project is part of ASP.NET 5. You can find samples, documentation, and getting started instructions for ASP.NET 5 at the [Home][home] repo.
 

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -1,0 +1,26 @@
+FROM mono:3.10
+
+ENV KRE_FEED https://www.myget.org/F/aspnetvnext/api/v2
+ENV KRE_USER_HOME /opt/kre
+
+RUN apt-get -qq update && apt-get -qqy install unzip
+
+ONBUILD RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/kvminstall.sh | sh
+ONBUILD RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
+	&& kvm install latest -a default \
+	&& kvm alias default | xargs -i ln -s $KRE_USER_HOME/packages/{} $KRE_USER_HOME/packages/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.0.0-rc2 \
+	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$KRE_USER_HOME/packages/default/bin


### PR DESCRIPTION
When a developer would like to run against the latest build of ASP.NET 5 he can use the `microsoft/aspnet:nightly` image. This image will point to the `https://www.myget.org/F/aspnetvnext/api/v2` feed to get the runtime and us an ONBUILD to get the latest version of KRE.

@giggio has brought this improvement in issue: [Create container for aspnet latest dev version](https://github.com/aspnet/aspnet-docker/issues/10)
