### PR TITLE
Switch to libuv 1.4.2 on new libuv home

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get -qqy install \
 	automake \
 	build-essential \
 	libtool
-RUN LIBUV_VERSION=1.0.0-rc2 \
-	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
 	&& sh autogen.sh && ./configure && make && make install \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \

--- a/1.0.0-beta2/Dockerfile
+++ b/1.0.0-beta2/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get -qqy install \
 	automake \
 	build-essential \
 	libtool
-RUN LIBUV_VERSION=1.0.0-rc2 \
-	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
 	&& sh autogen.sh && ./configure && make && make install \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \

--- a/1.0.0-beta3/Dockerfile
+++ b/1.0.0-beta3/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get -qqy install \
 	automake \
 	build-essential \
 	libtool
-RUN LIBUV_VERSION=1.0.0-rc2 \
-	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
 	&& sh autogen.sh && ./configure && make && make install \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get -qqy install \
 	automake \
 	build-essential \
 	libtool
-RUN LIBUV_VERSION=1.0.0-rc2 \
-	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
 	&& sh autogen.sh && ./configure && make && make install \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \


### PR DESCRIPTION
Made this PR regarding the discussion: https://github.com/aspnet/aspnet-docker/issues/21

I also performed a quick test against latest libuv 1.1.0 and it worked fine. Maybe we shall jump to 1.1.0 instead of 1.0.2. Regarding [1.1.0 changelog](https://github.com/libuv/libuv/releases/tag/v1.1.0), there are no significant changes (especially for unix env.), so in my opinion skipping 1.0.2 and move on to 1.1.0 is relatively safe.