### PR TITLE
Integrate CircleCI

### DIFF
--- a/.ci/build-all-tags.sh
+++ b/.ci/build-all-tags.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${IMAGE?"Need to pass IMAGE"}
+: ${1?"Need to pass search directory argument"}
+
+for tag in `.ci/find-tags.sh $1`; do
+	TAG=${IMAGE}:${tag}
+	echo "[CI] Building image '$TAG'..."
+	docker build -t $TAG $1/$tag
+done
+
+echo "[CI] All tags build fine."

--- a/.ci/build-app-image.sh
+++ b/.ci/build-app-image.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${1?"Need to pass BASE_IMAGE as argument"}
+: ${2?"Need to pass TEST_APP as argument"}
+: ${3?"Need to pass TAG as argument"}
+
+BASE_IMAGE=$1
+TEST_APP=$2
+TAG=$3
+
+echo "[CI] Injecting Dockerfile to project $TEST_APP..."
+cd  $SAMPLES_REPO/samples/$TEST_APP
+tee Dockerfile << EOF
+FROM $BASE_IMAGE
+COPY . /app
+WORKDIR /app
+RUN kpm restore
+ENV KRE_TRACE 1
+ENTRYPOINT sleep 10000 | k kestrel
+EOF
+
+echo "[CI] Building Docker image for $TEST_APP, will tag as '$TAG'..."
+docker build -t $TAG .
+echo "[CI] Built Docker image '$TAG'"

--- a/.ci/collect-logs.sh
+++ b/.ci/collect-logs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+mkdir -p container-logs
+
+for c in `docker ps -aq`; do
+	docker logs -t $c 2>&1 > ./container-logs/$c.log
+	echo "Saved logs for container $c."
+done

--- a/.ci/find-tags.sh
+++ b/.ci/find-tags.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+set -o pipefail # carry failures over pipes
+
+: ${1?"Need to pass Dockerfile search directory as argument"}
+
+cd $1
+find . -path ./.git -prune -o -name Dockerfile -print0 | xargs -0 -n1 dirname | sed -e "s/\.\///" | grep -v nightly

--- a/.ci/run-app.sh
+++ b/.ci/run-app.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${1?"Need to pass BASE_IMAGE as argument"}
+: ${2?"Need to pass TEST_APP as argument"}
+
+BASE_IMAGE=$1
+TEST_APP=$2
+TEST_PORT=$RANDOM
+
+APP_IMG_TAG=$(tr '[:upper:]' '[:lower:]' <<< $TEST_APP)_${TEST_PORT}
+
+# Build the app image
+.ci/build-app-image.sh $BASE_IMAGE $TEST_APP $APP_IMG_TAG
+
+# Start app
+.ci/start-container.sh 5004 $TEST_PORT $APP_IMG_TAG $APP_IMG_TAG
+
+echo "[CI] Verifying connectivity..."
+.ci/test-connection.sh http://localhost:$TEST_PORT

--- a/.ci/run-with-all-tags.sh
+++ b/.ci/run-with-all-tags.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${IMAGE?"Need to pass IMAGE"}
+: ${1?"Need to pass search directory as argument"}
+: ${2?"Need to pass sample app name as argument"}
+
+for tag in `.ci/find-tags.sh $1`; do
+	TAG=${IMAGE}:${tag}
+	echo "[CI] ----------------------------------"
+	echo "[CI] Verifying '$2' app with '$TAG'"
+	.ci/run-app.sh $TAG $2
+done
+
+echo "[CI] '$2' runs fine on all tags."

--- a/.ci/start-container.sh
+++ b/.ci/start-container.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${1?"Need to pass APP_PORT as argument"}
+: ${2?"Need to pass HOST_PORT as argument"}
+: ${3?"Need to pass CNT_NAME as argument"}
+: ${4?"Need to pass APP_IMG as argument"}
+
+APP_PORT=$1
+HOST_PORT=$2
+CNT_NAME=$3
+APP_IMG=$4
+
+SLEEP=10
+
+# Start container
+echo "[CI] Starting Docker container '$CNT_NAME', listening on port $HOST_PORT:"
+docker run -t -d -p $HOST_PORT:$APP_PORT --name $CNT_NAME $APP_IMG
+
+# Wait to bootstrap the app
+echo "[CI] Sleeping $SLEEP seconds to bootstrap the server..."
+sleep $SLEEP
+docker ps

--- a/.ci/test-connection.sh
+++ b/.ci/test-connection.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${1?"Need to pass URL"}
+URL=$1
+
+curl -vsSLI --retry 10 --retry-delay 3 $URL

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,25 @@
+machine:
+  services:
+    - docker
+  environment:
+    IMAGE: aspnet-ci
+    SAMPLES_REPO: $HOME/aspnet-Home
+
+general:
+  artifacts:
+    - "container-logs"
+
+checkout:
+  post:
+    - git clone -q git://github.com/aspnet/Home.git $SAMPLES_REPO
+
+dependencies:
+  override:
+    - .ci/build-all-tags.sh .
+
+test:
+  override:
+    - .ci/run-with-all-tags.sh . HelloWeb
+    - .ci/run-with-all-tags.sh . HelloMvc
+  post:
+    - .ci/collect-logs.sh


### PR DESCRIPTION
This commit adds required files to set up CI tests for new commits and pull requests to aspnet-docker repo using [CircleCI](http://circleci.com). Enabling CI will allow us to see if the built images are working fine and help us validate if the sent PRs are good and do not break the image. (see proposal at #23 for more)

### CI Test Steps

1. builds Docker images from using tags and tests (1.0.0-beta, nightly, etc)
2. creates containers running each sample aspnet app using those images built from previous step (e.g. HelloWeb, HelloMvc)
3. verifies connectivity to those web apps to see if the base image if healthy.

### Current Status

* This system currently works: https://circleci.com/gh/ahmetalpbalkan/aspnet-docker/10
* and here's how the build status badge looks like: [![Circle CI](https://circleci.com/gh/ahmetalpbalkan/aspnet-docker/tree/ci.svg?style=svg)](https://circleci.com/gh/ahmetalpbalkan/aspnet-docker/tree/ci)

### CR Tips

* I decided that CI scripts should live under  `.ci/` folder so that it doesn't look like it's at the same level with the image tags. 
* start reading from `circle.yml`.
* see [CI build](https://circleci.com/gh/ahmetalpbalkan/aspnet-docker/10) to see what steps are executed in which order.
* I'm no bash script ninja, so they might not be the best ones but they do just fine for now, comments appreciated about those.

### Future work

* Once merged, we need to set up a free account on CircleCI and create auto-builds for this repo.
* Only someone with admin privileges to this repo on GitHub can do it. (I don't have any)
* I can provide hands on help to do these.