### PR TITLE
also install node.js and grunt on images

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -3,7 +3,14 @@ FROM mono:3.10
 ENV KRE_VERSION 1.0.0-beta1
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy --no-install-recommends install \
+	git \
+	unzip
+
+# Install Node.js and Grunt
+RUN curl -sL https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -qqy nodejs \
+	&& npm install -g grunt-cli
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/v$KRE_VERSION/kvminstall.sh | sh
 RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \

--- a/1.0.0-beta2/Dockerfile
+++ b/1.0.0-beta2/Dockerfile
@@ -3,7 +3,14 @@ FROM mono:3.10
 ENV KRE_VERSION 1.0.0-beta2
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy --no-install-recommends install \
+	git \
+	unzip
+
+# Install Node.js and Grunt
+RUN curl -sL https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -qqy nodejs \
+	&& npm install -g grunt-cli
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/v$KRE_VERSION/kvminstall.sh | sh
 RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -3,7 +3,14 @@ FROM mono:3.10
 ENV KRE_FEED https://www.myget.org/F/aspnetvnext/api/v2
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy --no-install-recommends install \
+	git \
+	unzip
+
+# Install Node.js and Grunt
+RUN curl -sL https://deb.nodesource.com/setup | bash - \
+	&& apt-get install -qqy nodejs \
+	&& npm install -g grunt-cli
 
 ONBUILD RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/kvminstall.sh | sh
 ONBUILD RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \


### PR DESCRIPTION
Most ASP.NET 5 projects assumes the presence of Node.js and Grunt during builds. Examples are the MusicStore apps and the default VS2015 File->New Project templates.

The PR adds those requirements to the images. Note that Git is required to run Grunt. I've added the `--no-install-recommends` flag to pull in less stuff when installing Git.

It's unfortunate that there's no nodejs packages for Debian Wheezy. This could be significantly simplified if the upstream Mono image was based on Debian Jessie (which has nodejs package).