### PR TITLE
Upgrade mono base image to 3.12

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:3.10
+FROM mono:3.12
 
 ENV KRE_VERSION 1.0.0-beta1
 ENV KRE_USER_HOME /opt/kre

--- a/1.0.0-beta2/Dockerfile
+++ b/1.0.0-beta2/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:3.10
+FROM mono:3.12
 
 ENV KRE_VERSION 1.0.0-beta2
 ENV KRE_USER_HOME /opt/kre

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:3.10
+FROM mono:3.12
 
 ENV KRE_FEED https://www.myget.org/F/aspnetvnext/api/v2
 ENV KRE_USER_HOME /opt/kre


### PR DESCRIPTION
Although I have an IFTTT rule set up for new mono versions apparently it's not working enough well.

Heard about this via @markrendle.