### PR TITLE
Purge package lists to reduce image size (fixes #34)

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -3,7 +3,8 @@ FROM mono:3.12
 ENV KRE_VERSION 1.0.0-beta1
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy install unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/v$KRE_VERSION/kvminstall.sh | sh
 RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
@@ -11,11 +12,12 @@ RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
 	&& kvm alias default | xargs -i ln -s $KRE_USER_HOME/packages/{} $KRE_USER_HOME/packages/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
+RUN apt-get update && apt-get -qqy install \
 	autoconf \
 	automake \
 	build-essential \
-	libtool
+	libtool \
+	&& rm -rf /var/lib/apt/lists/*
 RUN LIBUV_VERSION=1.0.0-rc2 \
 	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \

--- a/1.0.0-beta2/Dockerfile
+++ b/1.0.0-beta2/Dockerfile
@@ -3,19 +3,21 @@ FROM mono:3.12
 ENV KRE_VERSION 1.0.0-beta2
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
-
+RUN apt-get -qq update && apt-get -qqy install unzip \
+    && rm -rf /var/lib/apt/lists/*
+    
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/v$KRE_VERSION/kvminstall.sh | sh
 RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
 	&& kvm install $KRE_VERSION -a default \
 	&& kvm alias default | xargs -i ln -s $KRE_USER_HOME/packages/{} $KRE_USER_HOME/packages/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
+RUN apt-get update && apt-get -qqy install \
 	autoconf \
 	automake \
 	build-essential \
-	libtool
+	libtool \
+	&& rm -rf /var/lib/apt/lists/*
 RUN LIBUV_VERSION=1.0.0-rc2 \
 	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -3,7 +3,8 @@ FROM mono:3.12
 ENV KRE_FEED https://www.myget.org/F/aspnetvnext/api/v2
 ENV KRE_USER_HOME /opt/kre
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy install unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 ONBUILD RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/kvminstall.sh | sh
 ONBUILD RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
@@ -11,11 +12,12 @@ ONBUILD RUN bash -c "source $KRE_USER_HOME/kvm/kvm.sh \
 	&& kvm alias default | xargs -i ln -s $KRE_USER_HOME/packages/{} $KRE_USER_HOME/packages/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
+RUN apt-get update && apt-get -qqy install \
 	autoconf \
 	automake \
 	build-essential \
-	libtool
+	libtool \
+	&& rm -rf /var/lib/apt/lists/*
 RUN LIBUV_VERSION=1.0.0-rc2 \
 	&& curl -sSL https://github.com/joyent/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \


### PR DESCRIPTION
This may increase build times (unless the two apt-get blocks are merged), but it should significantly reduce the end image size.