### PR TITLE
Take `nightly` out of CI.

### DIFF
--- a/.ci/find-tags.sh
+++ b/.ci/find-tags.sh
@@ -5,4 +5,4 @@ set -o pipefail # carry failures over pipes
 : ${1?"Need to pass Dockerfile search directory as argument"}
 
 cd $1
-find . -path ./.git -prune -o -name Dockerfile -print0 | xargs -0 -n1 dirname | sed -e "s/\.\///"
+find . -path ./.git -prune -o -name Dockerfile -print0 | xargs -0 -n1 dirname | sed -e "s/\.\///" | grep -v nightly


### PR DESCRIPTION
By definition nightly is supposed to break
regularly. Let's not allow that to effect
our master build or PR builds.

Undoing particular change made in #36.

Signed-off-by: Ahmet Alp Balkan <ahmetb@microsoft.com>