### PR TITLE
Renamed the nightly image to DNX

### DIFF
--- a/1.0.0-beta2/README.md
+++ b/1.0.0-beta2/README.md
@@ -19,10 +19,17 @@ Please [read this article][webdev-article] on .NET Web Development and Tools Blo
 
 This image provides the following environment variables:
 
-* `KRE_USER_HOME`: path to KRE installation (e.g. /opt/kre)
+* `KRE_USER_HOME`: path to KRE installation (e.g. /opt/kre) (except the `nightly` image)
 * `KRE_VERSION`: version of KRE (K Runtime) installed (except the `nightly` image)
 
 In addition to these, `PATH` is set to include the `k`/`kpm` executables.
+
+The `nightly` image provides the following environment variables:
+
+* `DNX_USER_HOME`: path to DNX installation (e.g. /opt/dnx)
+* `DNX_FEED`: url to the DNX nightly feed (e.g. https://www.myget.org/F/aspnetvnext/api/v2)
+
+In addition to these, `PATH` is set to include the `dnx`/`kpm` executables.
 
 ## Build Status
 

--- a/1.0.0-beta2/README.md
+++ b/1.0.0-beta2/README.md
@@ -29,7 +29,7 @@ The `nightly` image provides the following environment variables:
 * `DNX_USER_HOME`: path to DNX installation (e.g. /opt/dnx)
 * `DNX_FEED`: url to the DNX nightly feed (e.g. https://www.myget.org/F/aspnetvnext/api/v2)
 
-In addition to these, `PATH` is set to include the `dnx`/`kpm` executables.
+In addition to these, `PATH` is set to include the `dnx`/`k`/`kpm` executables.
 
 ## Build Status
 

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -1,14 +1,14 @@
 FROM mono:3.12
 
-ENV KRE_FEED https://www.myget.org/F/aspnetvnext/api/v2
-ENV KVM_USER_HOME /opt/k
+ENV DNX_FEED https://www.myget.org/F/aspnetvnext/api/v2
+ENV DNX_USER_HOME /opt/dnx
 
 RUN apt-get -qq update && apt-get -qqy install unzip
 
-ONBUILD RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/release/kvminstall.sh | KRE_USER_HOME=$KVM_USER_HOME KVM_BRANCH=dev sh
-ONBUILD RUN bash -c "source $KVM_USER_HOME/kvm/kvm.sh \
-	&& kvm install latest -a default \
-	&& kvm alias default | xargs -i ln -s $KVM_USER_HOME/runtimes/{} $KVM_USER_HOME/runtimes/default"
+ONBUILD RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh
+ONBUILD RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm install latest -a default \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
 RUN apt-get -qqy install \
@@ -26,4 +26,4 @@ RUN LIBUV_VERSION=1.0.0-rc2 \
 COPY NuGet.Config /tmp/
 RUN mkdir -p $HOME/.config/NuGet/ && mv /tmp/NuGet.Config $HOME/.config/NuGet/
 
-ENV PATH $PATH:$KVM_USER_HOME/runtimes/default/bin
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin


### PR DESCRIPTION
The ASP.NET 5 team has renamed `KRE, KVM` to `DNX, DNVM`. This pull request will make the nightly image to adapt to these changes.

Currently the `k` and `kpm` command are still usable, but this shouldn't affect the nightly image in the future.

Example Dockerfile
```
FROM aspnet:nightly

COPY . /app
WORKDIR /app
RUN kpm restore
ENV DNX_TRACE 1
ENTRYPOINT sleep 10000 | k kestrel
```