### PR TITLE
Checkout the according tag of the Home repo

### DIFF
--- a/.ci/run-with-all-tags.sh
+++ b/.ci/run-with-all-tags.sh
@@ -8,7 +8,7 @@ set -e 	# Exit immediately upon failure
 for tag in `.ci/find-tags.sh $1`; do
 	TAG=${IMAGE}:${tag}
 	BRANCH=master
-	if [[ ${tag} == "nightly" ]]; then BRANCH=dev; fi
+	if [[ ${tag} == "nightly" ]]; then BRANCH=dev; else BRANCH=tags/v${tag} ; fi
 	echo "[CI] ----------------------------------"
 	echo "[CI] Verifying '$2' app with '$TAG'"
 	.ci/run-app.sh $TAG $2 $BRANCH


### PR DESCRIPTION
This will fix the ci build on the master. It makes sure the right version (tag) of the aspnet/Home repository is checked out and that the samples uses the right NuGet package versions.