### PR TITLE
Removed k and kpm commands from the nightly image

### DIFF
--- a/1.0.0-beta3/README.md
+++ b/1.0.0-beta3/README.md
@@ -30,7 +30,7 @@ The `nightly` image provides the following environment variables:
 * `DNX_USER_HOME`: path to DNX installation (e.g. /opt/dnx)
 * `DNX_FEED`: url to the DNX nightly feed (e.g. https://www.myget.org/F/aspnetvnext/api/v2)
 
-In addition to these, `PATH` is set to include the `dnx`/`k`/`kpm` executables.
+In addition to these, `PATH` is set to include the `dnx`/`dnu` executables.
 
 ## Build Status
 


### PR DESCRIPTION
The `k` and `kpm` command are no longer part of the nightly and changed to `dnx` and `dnu`

```
FROM microsoft/aspnet:nightly
COPY . /app
WORKDIR /app
RUN dnu restore
ENTRYPOINT sleep 10000 | dnx /app kestrel
```