### PR TITLE
Added 1.0.0-beta4

### DIFF
--- a/1.0.0-beta4/Dockerfile
+++ b/1.0.0-beta4/Dockerfile
@@ -1,0 +1,36 @@
+FROM mono:4
+
+# Get build dependencies, download/build/install mono 4.1.0
+RUN apt-get update -qq \
+    && apt-get install -qqy git autoconf libtool automake build-essential mono-devel gettext unzip \
+    && git clone https://github.com/mono/mono.git \
+    && cd mono \
+    && git reset --hard 53dc56ee39a8e3b013231957aca4671b202c6410 \
+    && ./autogen.sh --prefix="/usr/local" \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf mono
+
+ENV DNX_VERSION 1.0.0-beta4
+ENV DNX_USER_HOME /opt/dnx
+
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
+RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm install $DNX_VERSION -a default \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin

--- a/1.0.0-beta4/README.md
+++ b/1.0.0-beta4/README.md
@@ -9,7 +9,8 @@ This project is part of ASP.NET 5. You can find samples, documentation, and gett
 
 ## Supported tags
 
-* [`1.0.0-beta3`, `latest`  _(1.0.0-beta3/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta3/Dockerfile)
+* [`1.0.0-beta4`, `latest`  _(1.0.0-beta4/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta4/Dockerfile)
+* [`1.0.0-beta3`,  _(1.0.0-beta3/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta3/Dockerfile)
 * [`1.0.0-beta2`,  _(1.0.0-beta2/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta2/Dockerfile)
 * [`1.0.0-beta1` _(1.0.0-beta1/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta1/Dockerfile)
 * [`coreclr-1.0.0-beta5-11624` _(coreclr-1.0.0-beta5-11624/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/coreclr-1.0.0-beta5-11624/Dockerfile)
@@ -20,10 +21,10 @@ Please [read this article][webdev-article] on .NET Web Development and Tools Blo
 
 This image provides the following environment variables:
 
-* `KVM_USER_HOME`: path to KRE installation (e.g. /opt/kre)
-* `KRE_VERSION`: version of KRE (K Runtime) installed
+* `DNX_USER_HOME`: path to DNX installation (e.g. /opt/dnx)
+* `DNX_VERSION`: version of DNX (.NET Execution Environment) installed
 
-In addition to these, `PATH` is set to include the `k`/`kpm` executables.
+In addition to these, `PATH` is set to include the `dnx`/`dnu` executables.
 
 ## Build Status
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-1.0.0-beta3/README.md
+1.0.0-beta4/README.md


### PR DESCRIPTION
This PR contains a container for beta 4 of ASP.NET 5. Unfortunately the aspnet/Home repo has been changed and gives problems with the CI scripts.