### PR TITLE
Fixed CI tests by excluding 1.0.0-beta3 and earlier

### DIFF
--- a/.ci/find-tags.sh
+++ b/.ci/find-tags.sh
@@ -5,4 +5,4 @@ set -o pipefail # carry failures over pipes
 : ${1?"Need to pass Dockerfile search directory as argument"}
 
 cd $1
-find . -path ./.git -prune -o -name Dockerfile -print0 | xargs -0 -n1 dirname | sed -e "s/\.\///" | grep -v nightly
+find . -path ./.git -prune -o -name Dockerfile -print0 | xargs -0 -n1 dirname | sed -e "s/\.\///" | grep -v '1.0.0-beta[1-3]' | grep -v 'coreclr-1.0.0-beta5-11624'

--- a/.ci/run-app.sh
+++ b/.ci/run-app.sh
@@ -3,17 +3,17 @@ set -e 	# Exit immediately upon failure
 
 : ${1?"Need to pass BASE_IMAGE as argument"}
 : ${2?"Need to pass TEST_APP as argument"}
-: ${3?"Need to pass BRANCH as argument"}
+: ${3?"Need to pass VERSION as argument"}
 
 BASE_IMAGE=$1
 TEST_APP=$2
 TEST_PORT=$RANDOM
-BRANCH=$3
+VERSION=$3
 
 APP_IMG_TAG=$(tr '[:upper:]' '[:lower:]' <<< $TEST_APP)_${TEST_PORT}
 
 # Build the app image
-.ci/build-app-image.sh $BASE_IMAGE $TEST_APP $APP_IMG_TAG $BRANCH
+.ci/build-app-image.sh $BASE_IMAGE $TEST_APP $APP_IMG_TAG $VERSION
 
 # Start app
 .ci/start-container.sh 5004 $TEST_PORT $APP_IMG_TAG $APP_IMG_TAG

--- a/.ci/run-with-all-tags.sh
+++ b/.ci/run-with-all-tags.sh
@@ -7,11 +7,9 @@ set -e 	# Exit immediately upon failure
 
 for tag in `.ci/find-tags.sh $1`; do
 	TAG=${IMAGE}:${tag}
-	BRANCH=master
-	if [[ ${tag} == "nightly" ]]; then BRANCH=dev; else BRANCH=tags/v${tag} ; fi
 	echo "[CI] ----------------------------------"
 	echo "[CI] Verifying '$2' app with '$TAG'"
-	.ci/run-app.sh $TAG $2 $BRANCH
+	.ci/run-app.sh $TAG $2 ${tag}
 done
 
 echo "[CI] '$2' runs fine on all tags."

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ general:
 
 checkout:
   post:
-    - git clone -q git://github.com/aspnet/Home.git $SAMPLES_REPO
+    - git clone -q git://github.com/aspnet/Home.git -b dev $SAMPLES_REPO
 
 dependencies:
   override:


### PR DESCRIPTION
This PR should fix the CI by excluding the 1.0.0-beta3 and earlier because of the breaking changes.