### PR TITLE
add beta5

### DIFF
--- a/1.0.0-beta5/Dockerfile
+++ b/1.0.0-beta5/Dockerfile
@@ -1,0 +1,26 @@
+FROM mono:4.0.1
+
+ENV DNX_VERSION 1.0.0-beta5
+ENV DNX_USER_HOME /opt/dnx
+
+RUN apt-get -qq update && apt-get -qqy install unzip
+
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
+RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm install $DNX_VERSION -a default \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin


### PR DESCRIPTION
As far as I know at the moment everything is the same for beta5 except for the version of the DNX. I just run the HelloWeb app with beta5 by updating just it.

However, you need to set the DNX_FEED variable and have a NuGet.Config that points at the right MyGet feed if you want to get packages and have it actually work. I didn't want to add that to the file because it is only temporary while the packages aren't actually released on NuGet.org.

I am assuming we can merge this without making it the latest. If so we should do that for now and then switch it once Beta5 is on NuGet and can work without the extra setup. Sound reasonable @ahmetalpbalkan?