### PR TITLE
Added dockerfile that works against dev branch.

### DIFF
--- a/1.0.0-dev/Dockerfile
+++ b/1.0.0-dev/Dockerfile
@@ -1,0 +1,30 @@
+FROM mono:4.0.1
+
+ENV DNX_VERSION dev
+ENV DNX_USER_HOME /opt/dnx
+ENV DNX_FEED https://www.myget.org/F/aspnetvnext/api/v2
+
+RUN apt-get -qq update && apt-get -qqy install unzip
+
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=$DNX_VERSION sh
+RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
+	&& dnvm install $DNX_VERSION -a default \
+	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+RUN mkdir -p ~/.config/NuGet/
+RUN curl -o ~/.config/NuGet/NuGet.Config -sSL https://gist.githubusercontent.com/Tazer/1ad0e439846ee26ef9a5/raw/901bd4ef59626ccab63622fa5ff7a711f24a22e9/Nuget.config

--- a/1.0.0-dev/Dockerfile
+++ b/1.0.0-dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM mono:4.0.1
 
-ENV DNX_VERSION dev
+ENV DNX_VERSION latest
 ENV DNX_USER_HOME /opt/dnx
 ENV DNX_FEED https://www.myget.org/F/aspnetvnext/api/v2
 
@@ -26,5 +26,6 @@ RUN LIBUV_VERSION=1.4.2 \
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
 
+# Needed to be able to install packages that are in dev branch (maybe this should be moved out of this?)
 RUN mkdir -p ~/.config/NuGet/
 RUN curl -o ~/.config/NuGet/NuGet.Config -sSL https://gist.githubusercontent.com/Tazer/1ad0e439846ee26ef9a5/raw/901bd4ef59626ccab63622fa5ff7a711f24a22e9/Nuget.config


### PR DESCRIPTION
Added a dockerfile that will work against dev.

I also added those line:
```
RUN mkdir -p ~/.config/NuGet/
RUN curl -o ~/.config/NuGet/NuGet.Config -sSL https://gist.githubusercontent.com/Tazer/1ad0e439846ee26ef9a5/raw/901bd4ef59626ccab63622fa5ff7a711f24a22e9/Nuget.config
```

But not sure if we should have it in the dockerfile or let the user configure that. If we have it like it's now.

You will just need 

```
COPY . /app
WORKDIR /app
RUN ["dnu", "restore"]

EXPOSE 5005
ENTRYPOINT ["dnx", ".", "kestrel"]
```

else the user needs to add:

```
RUN mkdir -p ~/.config/NuGet/
RUN curl -o ~/.config/NuGet/NuGet.Config -sSL https://gist.githubusercontent.com/Tazer/1ad0e439846ee26ef9a5/raw/901bd4ef59626ccab63622fa5ff7a711f24a22e9/Nuget.config

COPY . /app
WORKDIR /app
RUN ["dnu", "restore"]

EXPOSE 5005
ENTRYPOINT ["dnx", ".", "kestrel"]
```
