### PR TITLE
add latest

### DIFF
--- a/1.0.0-beta4/README.md
+++ b/1.0.0-beta4/README.md
@@ -13,11 +13,13 @@ This project is part of ASP.NET 5. You can find samples, documentation, and gett
 
 ## Supported tags
 
+* [`latest`, _(latest/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/latest/Dockerfile)
 * [`1.0.0-beta4`, `latest`  _(1.0.0-beta4/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta4/Dockerfile)
 * [`1.0.0-beta3`,  _(1.0.0-beta3/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta3/Dockerfile)
 * [`1.0.0-beta2`,  _(1.0.0-beta2/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta2/Dockerfile)
 * [`1.0.0-beta1` _(1.0.0-beta1/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/1.0.0-beta1/Dockerfile)
 * [`coreclr-1.0.0-beta5-11624` _(coreclr-1.0.0-beta5-11624/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/coreclr-1.0.0-beta5-11624/Dockerfile)
+* [`latest`, _(latest/Dockerfile)_](https://github.com/aspnet/aspnet-docker/blob/master/latest/Dockerfile)
 
 ## How to use this image
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,0 +1,27 @@
+FROM mono:4.0.1
+
+ENV DNX_VERSION latest
+ENV DNX_PATH /root/.dnx
+
+RUN apt-get -qq update && apt-get -qqy install unzip
+
+RUN touch ~/.profile
+RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=v$DNX_VERSION sh
+RUN bash -c "source $DNX_PATH/dnvm/dnvm.sh \
+	&& dnvm install -u $DNX_VERSION -a default \
+	&& dnvm alias default | xargs -i ln -s $DNX_PATH/runtimes/{} $DNX_PATH/runtimes/default"
+
+# Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
+RUN apt-get -qqy install \
+	autoconf \
+	automake \
+	build-essential \
+	libtool
+RUN LIBUV_VERSION=1.4.2 \
+	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
+	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
+	&& sh autogen.sh && ./configure && make && make install \
+	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
+	&& ldconfig
+
+ENV PATH $PATH:$DNX_PATH/runtimes/default/bin


### PR DESCRIPTION
The `latest` name is not ideal, but that's the `DNX_VERSION` that one has to specify.

I've gotten rid of the `/opt/dnx` thing - it causes problems for `dnu restore` I think.