### PR TITLE
Add MONO_THREADS_PER_CPU=2000 to prevent dnu restore failing

### DIFF
--- a/1.0.0-beta1/Dockerfile
+++ b/1.0.0-beta1/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$KRE_USER_HOME/packages/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta2/Dockerfile
+++ b/1.0.0-beta2/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$KRE_USER_HOME/packages/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta3/Dockerfile
+++ b/1.0.0-beta3/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$KVM_USER_HOME/runtimes/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta4/Dockerfile
+++ b/1.0.0-beta4/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta5/Dockerfile
+++ b/1.0.0-beta5/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta6/Dockerfile
+++ b/1.0.0-beta6/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000

--- a/1.0.0-beta7/Dockerfile
+++ b/1.0.0-beta7/Dockerfile
@@ -24,3 +24,6 @@ RUN LIBUV_VERSION=1.4.2 \
 	&& ldconfig
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
+
+# Prevent `dnu restore` from stalling (gh#63, gh#80)
+ENV MONO_THREADS_PER_CPU 2000


### PR DESCRIPTION
This was pretty annoying in #63 #80. Also causing CI to fail intermittently.