### PR TITLE
Combine some layers and purge packages to reduce image size.

### DIFF
--- a/1.0.0-beta7/Dockerfile
+++ b/1.0.0-beta7/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:4.0.1
 ENV DNX_VERSION 1.0.0-beta7
 ENV DNX_USER_HOME /opt/dnx
 
-RUN apt-get -qq update && apt-get -qqy install unzip
+RUN apt-get -qq update && apt-get -qqy install unzip && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
 RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
@@ -11,19 +11,21 @@ RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
 	&& dnvm alias default | xargs -i ln -s $DNX_USER_HOME/runtimes/{} $DNX_USER_HOME/runtimes/default"
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
-RUN apt-get -qqy install \
-	autoconf \
-	automake \
-	build-essential \
-	libtool
+# Combining this with the uninstall and purge will save us the space of the build tools in the image
 RUN LIBUV_VERSION=1.4.2 \
+	&& apt-get -qq update \
+	&& apt-get -qqy install autoconf automake build-essential libtool \
 	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \
 	&& cd /usr/local/src/libuv-$LIBUV_VERSION \
 	&& sh autogen.sh && ./configure && make && make install \
 	&& rm -rf /usr/local/src/libuv-$LIBUV_VERSION \
-	&& ldconfig
+	&& ldconfig \
+	&& apt-get -y purge autoconf automake build-essential libtool \
+	&& apt-get -y autoremove \
+	&& apt-get -y clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH $PATH:$DNX_USER_HOME/runtimes/default/bin
 
 # Prevent `dnu restore` from stalling (gh#63, gh#80)
-ENV MONO_THREADS_PER_CPU 2000
+ENV MONO_THREADS_PER_CPU 50


### PR DESCRIPTION
We had some people complain about the image size. 736 MB seems rather large, so I looked at the layers to see if there was something obvious we could trim. 

These changes purge the packages needed to build libuv in a single command and don't keep the metadata from apt-get in-between all the layers. Together it reduces the image size by just over 90MB (735.6MB to 638.5MB according to `docker images`) and doesn't look like it impacts readability of the Dockerfile too much.

What do you guys think? I've never really tried to keep an image small before. So I don't know if these sorts of tricks are what we want or if we should just be doing a cleanup at the end and then flattening the image with an export/import or something. Seems combining layers and keeping unnecessary files out of the image is probably better. 

Aside: I spoke to @BrennanConroy who said that someone on the Mono team said that 20 was a more appropriate number for MONO_THREADS_PER_CPU. So I thought I would throw that in here. We can do that as a separate PR if we don't do the rest of this.