### PR TITLE
Update libuv version

### DIFF
--- a/1.0.0-rc1-final-coreclr/Dockerfile
+++ b/1.0.0-rc1-final-coreclr/Dockerfile
@@ -16,7 +16,7 @@ RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
 # Combining this with the uninstall and purge will save us the space of the build tools in the image
-RUN LIBUV_VERSION=1.4.2 \
+RUN LIBUV_VERSION=1.7.5 \
 	&& apt-get -qq update \
 	&& apt-get -qqy install autoconf automake build-essential libtool \
 	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \

--- a/1.0.0-rc1-final/Dockerfile
+++ b/1.0.0-rc1-final/Dockerfile
@@ -16,7 +16,7 @@ RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \
 
 # Install libuv for Kestrel from source code (binary is not in wheezy and one in jessie is still too old)
 # Combining this with the uninstall and purge will save us the space of the build tools in the image
-RUN LIBUV_VERSION=1.4.2 \
+RUN LIBUV_VERSION=1.7.5 \
 	&& apt-get -qq update \
 	&& apt-get -qqy install autoconf automake build-essential libtool \
 	&& curl -sSL https://github.com/libuv/libuv/archive/v${LIBUV_VERSION}.tar.gz | tar zxfv - -C /usr/local/src \


### PR DESCRIPTION
Kestrel currently includes a version of libuv for Windows and OS X. But for Linux they rely on one being on the machine.

The version of libuv that the build of kestrel includes is actually pointing to a commit that is newer than the latest release from libuv. To bring us closer to that, I think we should update to at least the latest released version of libuv instead of the older 1.4.2 release we are currently using.

I will also send a PR to the docs repo to change the guidance so people who manually setup a machine are installing the newer version.

@halter73, @lodejard seem good to you?