### PR TITLE
(bugfix) updated SQLITE3 prevent EF7 crash on boilerplate ASPNET sites

### DIFF
--- a/1.0.0-rc1-update1-coreclr/Dockerfile
+++ b/1.0.0-rc1-update1-coreclr/Dockerfile
@@ -7,7 +7,14 @@ ENV DNX_USER_HOME /opt/DNX_BRANCH
 #the smaller base image. So we use this variable to overwrite the default detection.
 ENV DNX_RUNTIME_ID ubuntu.14.04-x64
 
-RUN apt-get -qq update && apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl3-gnutls zlib1g && rm -rf /var/lib/apt/lists/*
+# In order to address an issue with running a sqlite3 database on aspnet-docker-linux
+# a version of sqlite3 must be installed that is greater than or equal to 3.7.15
+# which is not available on the default apt sources list in this image.
+# ref: 	https://github.com/aspnet/EntityFramework/issues/3089
+# 		https://github.com/aspnet/aspnet-docker/issues/121
+RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
+
+RUN apt-get -qq update && apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl3-gnutls zlib1g  sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
 RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \

--- a/1.0.0-rc1-update1/Dockerfile
+++ b/1.0.0-rc1-update1/Dockerfile
@@ -7,7 +7,15 @@ ENV DNX_USER_HOME /opt/dnx
 #the smaller base image. So we use this variable to overwrite the default detection.
 ENV DNX_RUNTIME_ID ubuntu.14.04-x64
 
-RUN apt-get -qq update && apt-get -qqy install unzip libc6-dev libicu-dev && rm -rf /var/lib/apt/lists/*
+# In order to address an issue with running a sqlite3 database on aspnet-docker-linux
+# a version of sqlite3 must be installed that is greater than or equal to 3.7.15
+# which is not available on the default apt sources list in this image.
+# ref: 	https://github.com/aspnet/EntityFramework/issues/3089
+# 		https://github.com/aspnet/aspnet-docker/issues/121
+RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
+
+# added sqlite3 & libsqlite3-dev install for use with aspnet-generators (Entity framework)
+RUN apt-get -qq update && apt-get -qqy install unzip libc6-dev libicu-dev sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_USER_HOME=$DNX_USER_HOME DNX_BRANCH=v$DNX_VERSION sh
 RUN bash -c "source $DNX_USER_HOME/dnvm/dnvm.sh \


### PR DESCRIPTION
response to issue https://github.com/aspnet/aspnet-docker/issues/121 fixes an issue where database-enabled boilerplates from Yo generators would crash on attempted access

but how cool is this?! aspnet-docker running a container where I've actually registered and logged in locally.

![capture](https://cloud.githubusercontent.com/assets/355561/11552737/ed0eb802-9955-11e5-80b9-e33fa9d90d31.PNG)
