### PR TITLE
Update docker files for 1.0.1

### DIFF
--- a/1.0.1/jessie/build/Dockerfile
+++ b/1.0.1/jessie/build/Dockerfile
@@ -14,7 +14,7 @@ ENV NUGET_XMLDOC_MODE Skip
 COPY packagescache.project.json /tmp/packagescache.project.json
 
 # set up package cache
-RUN curl -o /tmp/packagescache.tar.gz https://dist.asp.net/packagecache/aspnetcore.packagecache-1.0.1-debian.8-x64.tar.gz && \
+RUN curl -o /tmp/packagescache.tar.gz http://dist.asp.net/packagecache/aspnetcore.packagecache-1.0.1-debian.8-x64.tar.gz && \
     mkdir /packagescache && cd /packagescache && \
     tar xvf /tmp/packagescache.tar.gz && \
     rm /tmp/packagescache.tar.gz && \

--- a/1.0.1/jessie/build/Dockerfile
+++ b/1.0.1/jessie/build/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -o /tmp/packagescache.tar.gz https://dist.asp.net/packagecache/aspnetco
     mkdir /packagescache && cd /packagescache && \
     tar xvf /tmp/packagescache.tar.gz && \
     rm /tmp/packagescache.tar.gz && \
-    # restore 1.0.0 ASP.NET packages
-    cd /tmp && dotnet restore packagescache.project.json --source https://www.myget.org/F/aspnet101/api/v3/index.json --fallbacksource https://api.nuget.org/v3/index.json && \
+    # restore 1.0.1 ASP.NET packages
+    cd /tmp && dotnet restore packagescache.project.json && \
     rm /tmp/packagescache.project.json && \
     cd /

--- a/1.0.1/jessie/build/packagescache.project.json
+++ b/1.0.1/jessie/build/packagescache.project.json
@@ -99,7 +99,6 @@
     "Microsoft.AspNetCore.Cryptography.Internal": "1.0.0",
     "Microsoft.AspNetCore.Cors": "1.0.0",
     "Microsoft.AspNetCore.CookiePolicy": "1.0.0",
-    "Microsoft.AspNetCore.Buffering": "0.1.0",
     "Microsoft.AspNetCore.Authorization": "1.0.0",
     "Microsoft.AspNetCore.Authentication.Twitter": "1.0.0",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.0.0",

--- a/1.0.1/jessie/product/Dockerfile
+++ b/1.0.1/jessie/product/Dockerfile
@@ -2,7 +2,7 @@
 FROM microsoft/dotnet:1.0.1-core
 
 # set up package cache
-RUN curl -o /tmp/packagescache.tar.gz https://dist.asp.net/packagecache/aspnetcore.packagecache-1.0.1-debian.8-x64.tar.gz && \
+RUN curl -o /tmp/packagescache.tar.gz http://dist.asp.net/packagecache/aspnetcore.packagecache-1.0.1-debian.8-x64.tar.gz && \
     mkdir /packagescache && cd /packagescache && \
     tar xvf /tmp/packagescache.tar.gz && \
     rm /tmp/packagescache.tar.gz && \


### PR DESCRIPTION
We pushed an incorrect package cache to azure blob storage last week. It is now replaced with the correct version. 