### PR TITLE
Add support for building/testing nanoserver images on a Nano machine

### DIFF
--- a/1.0/nanoserver/sdk/Dockerfile
+++ b/1.0/nanoserver/sdk/Dockerfile
@@ -4,7 +4,7 @@ FROM microsoft/dotnet:1.0.4-sdk-nanoserver-10.0.14393.953
 # Install node
 ENV NODE_VERSION 6.10.2
 
-RUN Invoke-WebRequest https://nodejs.org/dist/v${env:NODE_VERSION}/node-v${env:NODE_VERSION}-win-x64.zip -outfile node.zip; `
+RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSION}/node-v${env:NODE_VERSION}-win-x64.zip -outfile node.zip; `
     Expand-Archive node.zip -DestinationPath ${env:TEMP}/nodejs-tmp; `
     Move-Item ${env:TEMP}/nodejs-tmp/node-v${env:NODE_VERSION}-win-x64 ${env:ProgramFiles}/nodejs; `
     Remove-Item -Force node.zip; `

--- a/1.1/nanoserver/sdk/Dockerfile
+++ b/1.1/nanoserver/sdk/Dockerfile
@@ -4,7 +4,7 @@ FROM microsoft/dotnet:1.1.1-sdk-nanoserver-10.0.14393.953
 # Install node
 ENV NODE_VERSION 6.10.2
 
-RUN Invoke-WebRequest https://nodejs.org/dist/v${env:NODE_VERSION}/node-v${env:NODE_VERSION}-win-x64.zip -outfile node.zip; `
+RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSION}/node-v${env:NODE_VERSION}-win-x64.zip -outfile node.zip; `
     Expand-Archive node.zip -DestinationPath ${env:TEMP}/nodejs-tmp; `
     Move-Item ${env:TEMP}/nodejs-tmp/node-v${env:NODE_VERSION}-win-x64 ${env:ProgramFiles}/nodejs; `
     Remove-Item -Force node.zip; `

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -77,29 +77,37 @@ $images | ? { $_.type -eq 'sdk' } | % {
         -Command "C:/test/create-run-publish-app.ps1 C:/$app_name $framework"
 
     echo "----- Testing ${runtime_tag} with ${sdk_tag} app -----"
-    exec docker run -d -t `
-        -v "${app_dir}:C:/${app_name}" `
-        --workdir "C:/${app_name}" `
-        --name "runtime-test-${app_name}" `
-        -p 80:80 `
-        --entrypoint dotnet `
-        $runtime_tag `
-        "C:/${app_name}/publish/framework-dependent/${app_name}.dll"
+    try {
+        exec docker run -d -t `
+            -v "${app_dir}:C:/${app_name}" `
+            --workdir "C:/${app_name}" `
+            --name "runtime-test-${app_name}" `
+            -p 80:80 `
+            --entrypoint dotnet `
+            $runtime_tag `
+            "C:/${app_name}/publish/framework-dependent/${app_name}.dll"
 
-    $ip = get-ip "runtime-test-${app_name}"
-    WaitForSuccess "http://${ip}:80"
-    exec docker rm -f "runtime-test-${app_name}"
+        $ip = get-ip "runtime-test-${app_name}"
+        WaitForSuccess "http://${ip}:80"
+    }
+    finally {
+        exec docker rm -f "runtime-test-${app_name}"
+    }
 
     echo "----- Testing ${runtime_tag} with standalone ${sdk_tag} app -----"
-    exec docker run -d -t `
-        -v "${app_dir}:C:/${app_name}" `
-        --workdir "C:/${app_name}" `
-        --name "runtime-standalone-test-${app_name}" `
-        -p 80:80 `
-        --entrypoint "C:/${app_name}/publish/self-contained/${app_name}" `
-        $runtime_tag
+    try {
+        exec docker run -d -t `
+            -v "${app_dir}:C:/${app_name}" `
+            --workdir "C:/${app_name}" `
+            --name "runtime-standalone-test-${app_name}" `
+            -p 80:80 `
+            --entrypoint "C:/${app_name}/publish/self-contained/${app_name}" `
+            $runtime_tag
 
-    $ip = get-ip "runtime-standalone-test-${app_name}"
-    WaitForSuccess "http://${ip}:80"
-    exec docker rm -f "runtime-standalone-test-${app_name}"
+        $ip = get-ip "runtime-standalone-test-${app_name}"
+        WaitForSuccess "http://${ip}:80"
+    }
+    finally {
+        exec docker rm -f "runtime-standalone-test-${app_name}"
+    }
 }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -28,7 +28,7 @@ function WaitForSuccess($endpoint) {
     for ($i = 0; $i -lt 15; $i++) {
         write-host -f gray "Waiting for $endpoint"
         try {
-            iwr $endpoint
+            iwr -UseBasicParsing $endpoint
             return 0
         }
         catch {


### PR DESCRIPTION
The nano images fail to build on a Nano Server machine.  Also the tests fail on both Window Server and Nano Server machines.  

- Added -UseBasicParsing on the necessary Invoke-WebRequest calls.
- Added try-finally logic to the test script to ensure cleanup when the test fails.

Related #158

cc @natemcmaster 