### PR TITLE
Add support for producing multi-arch based tags

### DIFF
--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -6,16 +6,21 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 ## Supported tags
 
-- [`1.0.5`, `1.0`, `lts` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
-- [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
-- [`1.1.2`, `1.1`, `1`, `latest` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
-- [`2.0.0-preview1`, `2.0`, `2`, (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
-- [`2.0.0-preview1-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
-- [`1.0-1.1-2017-05`, `1.0-1.1` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
-- [`1.0-1.1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
-- [`1.0-2.0-preview1-2017-05`, `1.0-2.0-preview1` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
-- [`1.0-2.0-preview1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
+- `1.0.5`, `1.0`, `lts`
+    - [`1.0.5-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
+    - [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
+- `1.1.2`, `1.1`, `1`, `latest`
+    - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
+    - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
+- `2.0.0-preview1`, `2.0`, `2`
+    - [`2.0.0-preview1-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+    - [`2.0.0-preview1-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
+- `1.0-1.1-2017-05`, `1.0-1.1` (designed for CI builds)
+    - [`1.0-1.1-2017-05-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
+    - [`1.0-1.1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
+- `1.0-2.0-preview1-2017-05`, `1.0-2.0-preview1` (designed for CI builds)
+    - [`1.0-2.0-preview1-2017-05-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
+    - [`1.0-2.0-preview1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
 
 ## What is ASP.NET Core?
 

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -9,12 +9,15 @@ These images contain the runtime only. Use [`microsoft/aspnetcore-build`](https:
 
 ## Supported tags
 
-- [`1.0.5`, `1.0`, `lts` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)
-- [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/runtime/Dockerfile)
-- [`1.1.2`, `1.1`, `1`, `latest` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/runtime/Dockerfile)
-- [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/runtime/Dockerfile)
-- [`2.0.0-preview1`, `2.0`, `2`, (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
-- [`2.0.0-preview1-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/runtime/Dockerfile)
+- `1.0.5`, `1.0`, `lts`
+    - [`1.0.5-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)
+    - [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/runtime/Dockerfile)
+- `1.1.2`, `1.1`, `1`
+    - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/runtime/Dockerfile)
+    - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/runtime/Dockerfile)
+- `2.0.0-preview1`, `2.0`, `2`
+    - [`2.0.0-preview1-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
+    - [`2.0.0-preview1-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/runtime/Dockerfile)
 
 ## What is ASP.NET Core?
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+aspnet-docker
+=============
+
+This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at <https://docs.asp.net>.
+
+The repository is used to create multiple ASP.NET Core Docker images. Follow the links below for more details on each image.
+
+ - [`microsoft/aspnetcore-build`](README.aspnetcore-build.md)
+ - [`microsoft/aspnetcore`](README.aspnetcore.md)
+
+FYI: the `microsoft/aspnet` image has moved to <https://github.com/Microsoft/aspnet-docker>.

--- a/build-pipeline/aspnet-docker-linux-images.json
+++ b/build-pipeline/aspnet-docker-linux-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170519110355"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-linux-images.json
+++ b/build-pipeline/aspnet-docker-linux-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170522095246"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-linux-images.json
+++ b/build-pipeline/aspnet-docker-linux-images.json
@@ -1,0 +1,206 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "msimons/dotnet-buildtools-prereqs:image-builder-jessie"
+    },
+    "image-builder.args": {
+      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "aspnet-docker-linux-$(Build.BuildId)"
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "58cea29e-a1a3-4bde-9250-e69b3bd00e49",
+      "apiUrl": "https://api.github.com/repos/aspnet/aspnet-docker",
+      "branchesUrl": "https://api.github.com/repos/aspnet/aspnet-docker/branches",
+      "cloneUrl": "https://github.com/aspnet/aspnet-docker.git",
+      "refsUrl": "https://api.github.com/repos/aspnet/aspnet-docker/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/aspnet/aspnet-docker.git",
+    "type": "GitHub",
+    "name": "aspnet/aspnet-docker",
+    "url": "https://github.com/aspnet/aspnet-docker.git",
+    "defaultBranch": "master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    }
+  },
+  "id": 6214,
+  "name": "aspnet-docker-linux-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6214",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/aspnet-docker-linux-images.json
+++ b/build-pipeline/aspnet-docker-linux-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "msimons/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170519110355"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-post-image-build.json
+++ b/build-pipeline/aspnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170522095246"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-post-image-build.json
+++ b/build-pipeline/aspnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170519110355"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
@@ -156,7 +156,7 @@
       "allowOverride": true
     },
     "image-builder.containerName": {
-      "value": "aspnet-docker-linux-$(Build.BuildId)"
+      "value": "aspnet-docker-post-image-build-$(Build.BuildId)"
     },
     "PB.docker.password": {
       "value": null,
@@ -218,7 +218,7 @@
     }
   },
   "id": 6218,
-  "name": "aspnet-docker-manifest",
+  "name": "aspnet-docker-post-image-build",
   "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
   "path": "\\",
   "type": "build",

--- a/build-pipeline/aspnet-docker-post-image-build.json
+++ b/build-pipeline/aspnet-docker-post-image-build.json
@@ -1,0 +1,233 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Manifest",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.publishManifest.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Update Readme",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.updateReadme.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "msimons/dotnet-buildtools-prereqs:image-builder-jessie"
+    },
+    "image-builder.common.args": {
+      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
+      "allowOverride": true
+    },
+    "image-builder.publishManifest.args": {
+      "value": "--command PublishManifest $(image-builder.common.args)",
+      "allowOverride": true
+    },
+    "image-builder.updateReadme.args": {
+      "value": "--command UpdateReadme $(image-builder.common.args)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "aspnet-docker-linux-$(Build.BuildId)"
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "58cea29e-a1a3-4bde-9250-e69b3bd00e49",
+      "apiUrl": "https://api.github.com/repos/aspnet/aspnet-docker",
+      "branchesUrl": "https://api.github.com/repos/aspnet/aspnet-docker/branches",
+      "cloneUrl": "https://github.com/aspnet/aspnet-docker.git",
+      "refsUrl": "https://api.github.com/repos/aspnet/aspnet-docker/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/aspnet/aspnet-docker.git",
+    "type": "GitHub",
+    "name": "aspnet/aspnet-docker",
+    "url": "https://github.com/aspnet/aspnet-docker.git",
+    "defaultBranch": "master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    }
+  },
+  "id": 6218,
+  "name": "aspnet-docker-manifest",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/aspnet-docker-post-image-build.json
+++ b/build-pipeline/aspnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "msimons/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170519110355"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-windows-images.json
+++ b/build-pipeline/aspnet-docker-windows-images.json
@@ -1,0 +1,267 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create container",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy image-builder locally",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker ",
+        "arguments": "cp $(image-builder.containerName):/out $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup container",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "rmi -f $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
+        "arguments": "$(image-builder.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "msimons/dotnet-buildtools-prereqs:image-builder-nanoserver"
+    },
+    "image-builder.args": {
+      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "aspnet-docker-linux-$(Build.BuildId)"
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals Windows_NT"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "1",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "58cea29e-a1a3-4bde-9250-e69b3bd00e49",
+      "apiUrl": "https://api.github.com/repos/aspnet/aspnet-docker",
+      "branchesUrl": "https://api.github.com/repos/aspnet/aspnet-docker/branches",
+      "cloneUrl": "https://github.com/aspnet/aspnet-docker.git",
+      "refsUrl": "https://api.github.com/repos/aspnet/aspnet-docker/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/aspnet/aspnet-docker.git",
+    "type": "GitHub",
+    "name": "aspnet/aspnet-docker",
+    "url": "https://github.com/aspnet/aspnet-docker.git",
+    "defaultBranch": "master",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 159,
+    "name": "DotNetCore-Test",
+    "pool": {
+      "id": 83,
+      "name": "DotNetCore-Test"
+    }
+  },
+  "id": 6216,
+  "name": "aspnet-docker-windows-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/aspnet-docker-windows-images.json
+++ b/build-pipeline/aspnet-docker-windows-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "msimons/dotnet-buildtools-prereqs:image-builder-nanoserver"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170519110354"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-windows-images.json
+++ b/build-pipeline/aspnet-docker-windows-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170520053238"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170522094128"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/aspnet-docker-windows-images.json
+++ b/build-pipeline/aspnet-docker-windows-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170519110354"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170520053238"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -1,0 +1,48 @@
+{
+  "Repository": "aspnet-docker",
+  "Definitions": {
+    "Path": ".",
+    "Type": "VSTS",
+    "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection",
+    "SkipBranchAndVersionOverrides": "false"
+  },
+  "Pipelines": [
+    {
+      "Name": "Build Linux Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "aspnet-docker-linux-images"
+        }
+      ]
+    },
+    {
+      "Name": "Build Windows Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "aspnet-docker-windows-images"
+        }
+      ]
+    },
+    {
+      "Name": "Post Image Build",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "aspnet-docker-post-image-build"
+        }
+      ],
+      "DependsOn": [
+        "Build Windows Images",
+        "Build Linux Images"
+      ]
+    }
+  ]
+}

--- a/build.ps1
+++ b/build.ps1
@@ -21,9 +21,9 @@ gci $PSScriptRoot/*/nanoserver/*/Dockerfile | % {
     $type = $_.Directory.Name
     $version = $_.Directory.Parent.Parent.Name
     $tag = switch ($type) {
-        'sdk' { "$RootImageName/aspnetcore-build:${version}-nanoserver" }
-        'kitchensink' { "$RootImageName/aspnetcore-build:1.0-${version}-nanoserver" }
-        'runtime' { "$RootImageName/aspnetcore:${version}-nanoserver" }
+        'sdk' { "$RootImageName/aspnetcore-build:${version}" }
+        'kitchensink' { "$RootImageName/aspnetcore-build:1.0-${version}" }
+        'runtime' { "$RootImageName/aspnetcore:${version}" }
         default { throw "Unrecognized image type in $_" }
     }
     exec docker build --pull $(split-path -parent $_) -t $tag

--- a/build.sh
+++ b/build.sh
@@ -7,18 +7,20 @@ repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function build_dockerfiles {
     for dockerfile_dir in ${1}; do
         echo "----- ${dockerfile_dir} -----"
-        tag="$( sed -e 's/.\///' -e 's/jessie\///' -e 's/\//-/g' <<< "${dockerfile_dir}" )"
-        case $tag in
-            *-runtime )
-                docker_repo="test/aspnetcore"
+        version="$(dirname $(dirname $dockerfile_dir) | sed -e 's/.\///')"
+        case ${dockerfile_dir} in
+            *runtime )
+                tag="test/aspnetcore:$version"
                 ;;
-            *-sdk|*-kitchensink )
-                docker_repo="test/aspnetcore-build"
+            *sdk )
+                tag="test/aspnetcore-build:$version"
+                ;;
+            *kitchensink )
+                tag="test/aspnetcore-build:1.0-$version"
                 ;;
         esac
-        image_name="$docker_repo:$tag"
-        echo "----- Building ${image_name} -----"
-        docker build --pull -t "${image_name}" "${dockerfile_dir}"
+        echo "----- Building ${tag} -----"
+        docker build --pull -t "${tag}" "${dockerfile_dir}"
     done
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-set -e 	# Exit immediately upon failure
+set -e  # Exit immediately upon failure
 set -o pipefail  # Carry failures over pipes
 
 repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-docker_repo="test/aspnetcore"
 
 function build_dockerfiles {
     for dockerfile_dir in ${1}; do
         echo "----- ${dockerfile_dir} -----"
-        tag="${docker_repo}:$( sed -e 's/.\///' -e 's/jessie\///' -e 's/\//-/g' <<< "${dockerfile_dir}" )"
-        echo "----- Building ${tag} -----"
-        docker build --pull -t "${tag}" "${dockerfile_dir}"
+        tag="$( sed -e 's/.\///' -e 's/jessie\///' -e 's/\//-/g' <<< "${dockerfile_dir}" )"
+        case $tag in
+            *-runtime )
+                docker_repo="test/aspnetcore"
+                ;;
+            *-sdk|*-kitchensink )
+                docker_repo="test/aspnetcore-build"
+                ;;
+        esac
+        image_name="$docker_repo:$tag"
+        echo "----- Building ${image_name} -----"
+        docker build --pull -t "${image_name}" "${dockerfile_dir}"
     done
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,192 @@
+{
+  "Repos": [
+    {
+      "Name": "msimons/aspnetcore",
+      "ReadmePath": "README.aspnetcore.md",
+      "Images": [
+        {
+          "sharedTags": [
+            "1.0.5",
+            "1.0",
+            "lts"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/jessie/runtime",
+              "tags": [
+                "1.0.5-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/nanoserver/runtime",
+              "tags": [
+                "1.0.5-nanoserver",
+                "1.0.5-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "1.1.2",
+            "1.1",
+            "1",
+            "latest"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/jessie/runtime",
+              "tags": [
+                "1.1.2-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/nanoserver/runtime",
+              "tags": [
+                "1.1.2-nanoserver",
+                "1.1.2-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview1",
+            "2.0",
+            "2"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/jessie/runtime",
+              "tags": [
+                "2.0.0-preview1-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/nanoserver/runtime",
+              "tags": [
+                "2.0.0-preview1-nanoserver",
+                "2.0.0-preview1-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Name": "msimons/aspnetcore-build",
+      "ReadmePath": "README.aspnetcore-build.md",
+      "Images": [
+        {
+          "sharedTags": [
+            "1.0.5",
+            "1.0",
+            "lts"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/jessie/sdk",
+              "tags": [
+                "1.0.5-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/nanoserver/sdk",
+              "tags": [
+                "1.0.5-nanoserver",
+                "1.0.5-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "1.1.2",
+            "1.1",
+            "1",
+            "latest"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/jessie/sdk",
+              "tags": [
+                "1.1.2-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/nanoserver/sdk",
+              "tags": [
+                "1.1.2-nanoserver",
+                "1.1.2-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview1",
+            "2.0",
+            "2"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/jessie/sdk",
+              "tags": [
+                "2.0.0-preview1-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/nanoserver/sdk",
+              "tags": [
+                "2.0.0-preview1-nanoserver",
+                "2.0.0-preview1-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "1.0-1.1-2017-05",
+            "1.0-1.1"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/jessie/kitchensink",
+              "tags": [
+                "1.0-1.1-2017-05-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/nanoserver/kitchensink",
+              "tags": [
+                "1.0-1.1-2017-05-nanoserver",
+                "1.0-1.1-2017-05-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "1.0-2.0-preview1-2017-05",
+            "1.0-2.0-preview1"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/jessie/kitchensink",
+              "tags": [
+                "1.0-2.0-preview1-2017-05-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/nanoserver/kitchensink",
+              "tags": [
+                "1.0-2.0-preview1-2017-05-nanoserver",
+                "1.0-2.0-preview1-2017-05-nanoserver-10.0.14393.1198"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,12 @@
 {
-  "Repos": [
+  "tagVariables": {
+    "nanoServerVersion": "10.0.14393.1198"
+  },
+  "repos": [
     {
-      "Name": "msimons/aspnetcore",
-      "ReadmePath": "README.aspnetcore.md",
-      "Images": [
+      "name": "msimons/aspnetcore",
+      "readmePath": "README.aspnetcore.md",
+      "images": [
         {
           "sharedTags": [
             "1.0.5",
@@ -21,7 +24,7 @@
               "dockerfile": "1.0/nanoserver/runtime",
               "tags": [
                 "1.0.5-nanoserver",
-                "1.0.5-nanoserver-10.0.14393.1198"
+                "1.0.5-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -44,7 +47,7 @@
               "dockerfile": "1.1/nanoserver/runtime",
               "tags": [
                 "1.1.2-nanoserver",
-                "1.1.2-nanoserver-10.0.14393.1198"
+                "1.1.2-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -66,7 +69,7 @@
               "dockerfile": "2.0/nanoserver/runtime",
               "tags": [
                 "2.0.0-preview1-nanoserver",
-                "2.0.0-preview1-nanoserver-10.0.14393.1198"
+                "2.0.0-preview1-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -74,9 +77,9 @@
       ]
     },
     {
-      "Name": "msimons/aspnetcore-build",
-      "ReadmePath": "README.aspnetcore-build.md",
-      "Images": [
+      "name": "msimons/aspnetcore-build",
+      "readmePath": "README.aspnetcore-build.md",
+      "images": [
         {
           "sharedTags": [
             "1.0.5",
@@ -94,7 +97,7 @@
               "dockerfile": "1.0/nanoserver/sdk",
               "tags": [
                 "1.0.5-nanoserver",
-                "1.0.5-nanoserver-10.0.14393.1198"
+                "1.0.5-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -117,7 +120,7 @@
               "dockerfile": "1.1/nanoserver/sdk",
               "tags": [
                 "1.1.2-nanoserver",
-                "1.1.2-nanoserver-10.0.14393.1198"
+                "1.1.2-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -139,7 +142,7 @@
               "dockerfile": "2.0/nanoserver/sdk",
               "tags": [
                 "2.0.0-preview1-nanoserver",
-                "2.0.0-preview1-nanoserver-10.0.14393.1198"
+                "2.0.0-preview1-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -160,7 +163,7 @@
               "dockerfile": "1.1/nanoserver/kitchensink",
               "tags": [
                 "1.0-1.1-2017-05-nanoserver",
-                "1.0-1.1-2017-05-nanoserver-10.0.14393.1198"
+                "1.0-1.1-2017-05-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -181,7 +184,7 @@
               "dockerfile": "2.0/nanoserver/kitchensink",
               "tags": [
                 "1.0-2.0-preview1-2017-05-nanoserver",
-                "1.0-2.0-preview1-2017-05-nanoserver-10.0.14393.1198"
+                "1.0-2.0-preview1-2017-05-nanoserver-$(nanoServerVersion)"
               ]
             }
           }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   },
   "repos": [
     {
-      "name": "msimons/aspnetcore",
+      "name": "microsoft/aspnetcore",
       "readmePath": "README.aspnetcore.md",
       "images": [
         {
@@ -77,7 +77,7 @@
       ]
     },
     {
-      "name": "msimons/aspnetcore-build",
+      "name": "microsoft/aspnetcore-build",
       "readmePath": "README.aspnetcore-build.md",
       "images": [
         {

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -19,12 +19,11 @@ function __exec {
 cd $1
 
 echo "Testing framework-dependent deployment"
-if [[ $2 == "2.0"* ]]; then
-    __exec dotnet new web --framework netcoreapp2.0 --no-restore
-elif [[ $2 == "1.1"* ]]; then
-    __exec dotnet new web --framework netcoreapp1.1
+framework=$2
+if [[ $framework == 'netcoreapp1.0' || $framework == 'netcoreapp1.1' ]]; then
+    __exec dotnet new web --framework $framework
 else
-    __exec dotnet new web --framework netcoreapp1.0
+    __exec dotnet new web --framework $framework --no-restore
 fi
 
 # restore only from $HOME/.nuget/packages to ensure the cache has already been warmed up

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -57,8 +57,8 @@ gci $PSScriptRoot/../*/nanoserver/sdk/Dockerfile | % {
 
     $version = $_.Directory.Parent.Parent.Name
     $framework = "netcoreapp${version}"
-    $sdk_tag = "$RootImageName/aspnetcore-build:${version}-nanoserver"
-    $runtime_tag = "$RootImageName/aspnetcore:${version}-nanoserver"
+    $sdk_tag = "$RootImageName/aspnetcore-build:${version}"
+    $runtime_tag = "$RootImageName/aspnetcore:${version}"
 
     echo "---- Testing ${sdk_tag} and ${runtime_tag} ----"
     exec docker run -t `


### PR DESCRIPTION
- [x] Switch over to use published version of https://github.com/dotnet/docker-tools.  Currently using one off copy in order to work around a couple limitations.
- [x] Switch over to use microsoft Docker Hub repo.  Currently testing against [msimons/aspnetcore](https://hub.docker.com/r/msimons/aspnetcore/) and [msimons/aspnetcore-build repos](https://hub.docker.com/r/msimons/aspnetcore-build/).
- [x] Finalize on README file names and locations.  @natemcmaster, @glennc I would like feedback on this.  I moved the readmes to the root of the repo as this is now possible the way we are building the images.  Were you thinking there should also be a new uber README that covers the entire repo?
- [x] ~~Tests need some refactoring in order to be hooked up to the image builder tool.  Need to remove the local volume mapping.  It may make most sense to treat this as a separate PR.~~  https://github.com/aspnet/aspnet-docker/issues/236