### PR TITLE
Prepare 2.0.0-preview2 nightly images

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 build_script:
-  - ps: .\build.ps1 -Nightly
+  - ps: .\build.ps1
 test_script:
-  - ps: .\test\test.ps1 -Nightly
+  - ps: .\test\test.ps1
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
 services:
   - docker
 before_install:
-  - ./build.sh --nightly
+  - ./build.sh
   - docker build --rm -t testrunner -f ./test/Dockerfile.testrunner.linux .
-script: /bin/bash -c "docker run --add-host dockerhost:$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/test.ps1 -HostIP dockerhost -Nightly"
+script: /bin/bash -c "docker run --add-host dockerhost:$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/test.ps1 -HostIP dockerhost"

--- a/1.0/jessie/runtime/Dockerfile
+++ b/1.0/jessie/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.0.5-runtime
+FROM microsoft/dotnet-nightly:1.0.5-runtime
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.0/jessie/sdk/Dockerfile
+++ b/1.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.0.5-sdk
+FROM microsoft/dotnet-nightly:1.0.5-sdk
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.0/nanoserver/runtime/Dockerfile
+++ b/1.0/nanoserver/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.0.5-runtime-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:1.0.5-runtime-nanoserver-10.0.14393.1358
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.0/nanoserver/sdk/Dockerfile
+++ b/1.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.0.5-sdk-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:1.0.5-sdk-nanoserver-10.0.14393.1358
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -12,7 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.13.1.windows.1/MinGit-2.13.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/1.1/jessie/kitchensink/Dockerfile
+++ b/1.1/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-sdk
+FROM microsoft/dotnet-nightly:1.1.2-sdk
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/jessie/runtime/Dockerfile
+++ b/1.1/jessie/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-runtime
+FROM microsoft/dotnet-nightly:1.1.2-runtime
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/jessie/sdk/Dockerfile
+++ b/1.1/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-sdk
+FROM microsoft/dotnet-nightly:1.1.2-sdk
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver/kitchensink/Dockerfile
+++ b/1.1/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.2-sdk-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:1.1.2-sdk-nanoserver-10.0.14393.1358
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -12,7 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.13.1.windows.1/MinGit-2.13.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/1.1/nanoserver/runtime/Dockerfile
+++ b/1.1/nanoserver/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.2-runtime-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:1.1.2-runtime-nanoserver-10.0.14393.1358
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver/sdk/Dockerfile
+++ b/1.1/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.2-sdk-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:1.1.2-sdk-nanoserver-10.0.14393.1358
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -12,7 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.13.1.windows.1/MinGit-2.13.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -60,7 +60,7 @@ COPY packagescache.csproj /tmp/warmup/
 
 # warm up package cache
 RUN dotnet restore /tmp/warmup/packagescache.csproj \
-      --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json \
+      --source https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json \
       --source https://api.nuget.org/v3/index.json \
     && rm -rf /tmp/warmup/
 

--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-preview1-sdk
+FROM microsoft/dotnet-nightly:2.0.0-preview2-sdk
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -60,6 +60,7 @@ COPY packagescache.csproj /tmp/warmup/
 
 # warm up package cache
 RUN dotnet restore /tmp/warmup/packagescache.csproj \
+      --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json \
       --source https://api.nuget.org/v3/index.json \
     && rm -rf /tmp/warmup/
 

--- a/2.0/jessie/kitchensink/packagescache.csproj
+++ b/2.0/jessie/kitchensink/packagescache.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 

--- a/2.0/jessie/kitchensink/packagescache.csproj
+++ b/2.0/jessie/kitchensink/packagescache.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/jessie/kitchensink/packagescache.csproj
+++ b/2.0/jessie/kitchensink/packagescache.csproj
@@ -3,13 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
-    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25661" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/jessie/kitchensink/packagescache.csproj
+++ b/2.0/jessie/kitchensink/packagescache.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/jessie/runtime/Dockerfile
+++ b/2.0/jessie/runtime/Dockerfile
@@ -5,7 +5,7 @@ ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
 RUN curl -o /tmp/runtimestore.tar.gz \
-    https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.linux-preview2-25722.tar.gz
+    https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.linux-preview2-25722.tar.gz \
     && export DOTNET_HOME=$(dirname $(readlink $(which dotnet))) \
     && tar -x -C $DOTNET_HOME -f /tmp/runtimestore.tar.gz \
     && rm /tmp/runtimestore.tar.gz

--- a/2.0/jessie/runtime/Dockerfile
+++ b/2.0/jessie/runtime/Dockerfile
@@ -5,7 +5,7 @@ ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
 RUN curl -o /tmp/runtimestore.tar.gz \
-    https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.linux-preview2-25722.tar.gz \
+    https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-186/Build.RS.linux-preview2-25661.tar.gz \
     && export DOTNET_HOME=$(dirname $(readlink $(which dotnet))) \
     && tar -x -C $DOTNET_HOME -f /tmp/runtimestore.tar.gz \
     && rm /tmp/runtimestore.tar.gz

--- a/2.0/jessie/runtime/Dockerfile
+++ b/2.0/jessie/runtime/Dockerfile
@@ -4,9 +4,8 @@ FROM microsoft/dotnet-nightly:2.0.0-preview2-runtime
 ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
-ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview2-25704
 RUN curl -o /tmp/runtimestore.tar.gz \
-    https://aspnetci.blob.core.windows.net/runtimestore/${ASPNETCORE_RUNTIME_STORE_VERSION}/linux-x64/aspnetcore.runtimestore.tar.gz \
+    https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.linux-preview2-25722.tar.gz
     && export DOTNET_HOME=$(dirname $(readlink $(which dotnet))) \
     && tar -x -C $DOTNET_HOME -f /tmp/runtimestore.tar.gz \
     && rm /tmp/runtimestore.tar.gz

--- a/2.0/jessie/runtime/Dockerfile
+++ b/2.0/jessie/runtime/Dockerfile
@@ -1,12 +1,12 @@
-FROM microsoft/dotnet:2.0.0-preview1-runtime
+FROM microsoft/dotnet-nightly:2.0.0-preview2-runtime
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
-ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview1
+ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview2-25704
 RUN curl -o /tmp/runtimestore.tar.gz \
-    https://dist.asp.net/packagecache/${ASPNETCORE_RUNTIME_STORE_VERSION}/linux-x64/aspnetcore.runtimestore.tar.gz \
+    https://aspnetci.blob.core.windows.net/runtimestore/${ASPNETCORE_RUNTIME_STORE_VERSION}/linux-x64/aspnetcore.runtimestore.tar.gz \
     && export DOTNET_HOME=$(dirname $(readlink $(which dotnet))) \
     && tar -x -C $DOTNET_HOME -f /tmp/runtimestore.tar.gz \
     && rm /tmp/runtimestore.tar.gz

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-preview1-sdk
+FROM microsoft/dotnet-nightly:2.0.0-preview2-sdk
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -41,6 +41,7 @@ RUN buildDeps='xz-utils' \
 # warmup NuGet package cache
 COPY packagescache.csproj /tmp/warmup/
 RUN dotnet restore /tmp/warmup/packagescache.csproj \
+      --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json \
       --source https://api.nuget.org/v3/index.json \
     && rm -rf /tmp/warmup/
 

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -41,7 +41,7 @@ RUN buildDeps='xz-utils' \
 # warmup NuGet package cache
 COPY packagescache.csproj /tmp/warmup/
 RUN dotnet restore /tmp/warmup/packagescache.csproj \
-      --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json \
+      --source https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json \
       --source https://api.nuget.org/v3/index.json \
     && rm -rf /tmp/warmup/
 

--- a/2.0/jessie/sdk/packagescache.csproj
+++ b/2.0/jessie/sdk/packagescache.csproj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
-    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25661" />
   </ItemGroup>
 
 </Project>

--- a/2.0/jessie/sdk/packagescache.csproj
+++ b/2.0/jessie/sdk/packagescache.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/2.0/jessie/sdk/packagescache.csproj
+++ b/2.0/jessie/sdk/packagescache.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
   </ItemGroup>
 
 </Project>

--- a/2.0/jessie/sdk/packagescache.csproj
+++ b/2.0/jessie/sdk/packagescache.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>debian.8-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
   </ItemGroup>
 
 </Project>

--- a/2.0/nanoserver/kitchensink/Dockerfile
+++ b/2.0/nanoserver/kitchensink/Dockerfile
@@ -35,6 +35,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 # warmup up NuGet package cache
 COPY packagescache.csproj C:/warmup/packagescache.csproj
 RUN dotnet restore C:/warmup/packagescache.csproj `
-        --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json `
+        --source https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json `
         --source https://api.nuget.org/v3/index.json; `
     Remove-Item -Recurse -Force C:/warmup

--- a/2.0/nanoserver/kitchensink/Dockerfile
+++ b/2.0/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-preview1-sdk-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:2.0.0-preview2-sdk-nanoserver-10.0.14393.1358
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -12,7 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.13.1.windows.1/MinGit-2.13.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 
@@ -35,5 +35,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 # warmup up NuGet package cache
 COPY packagescache.csproj C:/warmup/packagescache.csproj
 RUN dotnet restore C:/warmup/packagescache.csproj `
-      --source https://api.nuget.org/v3/index.json; `
+        --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json `
+        --source https://api.nuget.org/v3/index.json; `
     Remove-Item -Recurse -Force C:/warmup

--- a/2.0/nanoserver/kitchensink/packagescache.csproj
+++ b/2.0/nanoserver/kitchensink/packagescache.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/nanoserver/kitchensink/packagescache.csproj
+++ b/2.0/nanoserver/kitchensink/packagescache.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/nanoserver/kitchensink/packagescache.csproj
+++ b/2.0/nanoserver/kitchensink/packagescache.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 

--- a/2.0/nanoserver/kitchensink/packagescache.csproj
+++ b/2.0/nanoserver/kitchensink/packagescache.csproj
@@ -3,13 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
-    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25661" />
   </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0'">

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -5,8 +5,7 @@ FROM microsoft/dotnet-nightly:2.0.0-preview2-runtime-nanoserver-10.0.14393.1358
 ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
-ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview2-25704
-RUN $downloadUrl = \" https://aspnetci.blob.core.windows.net/runtimestore/${env:ASPNETCORE_RUNTIME_STORE_VERSION}/win-x64/aspnetcore.runtimestore.zip\"; `
+RUN $downloadUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.winx64-preview2-25722.zip'; `
     Write-Host \"Downloading and extracting $downloadUrl\"; `
     Invoke-WebRequest $downloadUrl -OutFile cache.zip; `
     $env:DOTNET_HOME = $(Split-Path -Parent (Get-Command dotnet.exe).Source); `

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -1,12 +1,12 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-preview1-runtime-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:2.0.0-preview2-runtime-nanoserver-10.0.14393.1358
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
-ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview1
-RUN $downloadUrl = \"https://distaspnet.blob.core.windows.net/packagecache/${env:ASPNETCORE_RUNTIME_STORE_VERSION}/win-x64/aspnetcore.runtimestore.zip\"; `
+ENV ASPNETCORE_RUNTIME_STORE_VERSION 2.0.0-preview2-25704
+RUN $downloadUrl = \" https://aspnetci.blob.core.windows.net/runtimestore/${env:ASPNETCORE_RUNTIME_STORE_VERSION}/win-x64/aspnetcore.runtimestore.zip\"; `
     Write-Host \"Downloading and extracting $downloadUrl\"; `
     Invoke-WebRequest $downloadUrl -OutFile cache.zip; `
     $env:DOTNET_HOME = $(Split-Path -Parent (Get-Command dotnet.exe).Source); `

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -5,7 +5,7 @@ FROM microsoft/dotnet-nightly:2.0.0-preview2-runtime-nanoserver-10.0.14393.1358
 ENV ASPNETCORE_URLS http://+:80
 
 # set up the runtime store
-RUN $downloadUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-201/Build.RS.winx64-preview2-25722.zip'; `
+RUN $downloadUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.0-preview2-186/Build.RS.winx64-preview2-25661.zip'; `
     Write-Host \"Downloading and extracting $downloadUrl\"; `
     Invoke-WebRequest $downloadUrl -OutFile cache.zip; `
     $env:DOTNET_HOME = $(Split-Path -Parent (Get-Command dotnet.exe).Source); `

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-preview1-sdk-nanoserver-10.0.14393.1358
+FROM microsoft/dotnet-nightly:2.0.0-preview2-sdk-nanoserver-10.0.14393.1358
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -12,7 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.13.1.windows.1/MinGit-2.13.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 
@@ -22,5 +22,6 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '/nodejs' + ';' + $Env:
 COPY packagescache.csproj C:/warmup/packagescache.csproj
 
 RUN dotnet restore C:/warmup/packagescache.csproj `
-      --source https://api.nuget.org/v3/index.json; `
+        --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json `
+        --source https://api.nuget.org/v3/index.json; `
     Remove-Item -Recurse -Force C:/warmup

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -22,6 +22,6 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '/nodejs' + ';' + $Env:
 COPY packagescache.csproj C:/warmup/packagescache.csproj
 
 RUN dotnet restore C:/warmup/packagescache.csproj `
-        --source https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json `
+        --source https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json `
         --source https://api.nuget.org/v3/index.json; `
     Remove-Item -Recurse -Force C:/warmup

--- a/2.0/nanoserver/sdk/packagescache.csproj
+++ b/2.0/nanoserver/sdk/packagescache.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
   </ItemGroup>
 
 </Project>

--- a/2.0/nanoserver/sdk/packagescache.csproj
+++ b/2.0/nanoserver/sdk/packagescache.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25704" />
   </ItemGroup>
 
 </Project>

--- a/2.0/nanoserver/sdk/packagescache.csproj
+++ b/2.0/nanoserver/sdk/packagescache.csproj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
-    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25722" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25661" />
   </ItemGroup>
 
 </Project>

--- a/2.0/nanoserver/sdk/packagescache.csproj
+++ b/2.0/nanoserver/sdk/packagescache.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net451+win8</PackageTargetFallback>
+    <!--<AssetTargetFallback>$(AssetTargetFallback);portable-net451+win8</AssetTargetFallback>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -1,8 +1,10 @@
 param(
     # Set to 'microsoft' on build servers
     [string]$RootImageName='test',
+    # Set to 'jessie' if building the Linux containers
+    [string]$Os='nanoserver',
     # Set on build servers
-    [switch]$Nightly
+    [switch]$Nightly=$true
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,7 +23,7 @@ function exec($cmd) {
 $suffix = if ($Nightly) { '-nightly' } else { '' }
 
 # Main
-gci $PSScriptRoot/*/nanoserver/*/Dockerfile | % {
+gci $PSScriptRoot/*/$os/*/Dockerfile | % {
     $type = $_.Directory.Name
     $version = $_.Directory.Parent.Parent.Name
     $tag = switch ($type) {

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,11 @@
 set -e  # Exit immediately upon failure
 set -o pipefail  # Carry failures over pipes
 
-suffix=''
+suffix='-nightly'
 while [[ $# > 0 ]]; do
     case $1 in
-        --nightly)
-            suffix='-nightly'
+        --no-nightly)
+            suffix=''
             ;;
         *)
             break

--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
         },
         {
           "sharedTags": [
-            "2.0.0-preview1",
+            "2.0.0-preview2",
             "2.0",
             "2"
           ],
@@ -71,14 +71,14 @@
             "linux": {
               "dockerfile": "2.0/jessie/runtime",
               "tags": [
-                "2.0.0-preview1-jessie"
+                "2.0.0-preview2-jessie"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/runtime",
               "tags": [
-                "2.0.0-preview1-nanoserver",
-                "2.0.0-preview1-nanoserver-$(nanoServerVersion)"
+                "2.0.0-preview2-nanoserver",
+                "2.0.0-preview2-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -136,7 +136,7 @@
         },
         {
           "sharedTags": [
-            "2.0.0-preview1",
+            "2.0.0-preview2",
             "2.0",
             "2"
           ],
@@ -144,14 +144,14 @@
             "linux": {
               "dockerfile": "2.0/jessie/sdk",
               "tags": [
-                "2.0.0-preview1-jessie"
+                "2.0.0-preview2-jessie"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/sdk",
               "tags": [
-                "2.0.0-preview1-nanoserver",
-                "2.0.0-preview1-nanoserver-$(nanoServerVersion)"
+                "2.0.0-preview2-nanoserver",
+                "2.0.0-preview2-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -179,22 +179,22 @@
         },
         {
           "sharedTags": [
-            "1.0-2.0-preview1-2017-05",
-            "1.0-2.0-preview1",
+            "1.0-2.0-preview2-2017-06",
+            "1.0-2.0-preview2",
             "1.0-2.0"
           ],
           "platforms": {
             "linux": {
               "dockerfile": "2.0/jessie/kitchensink",
               "tags": [
-                "1.0-2.0-preview1-2017-05-jessie"
+                "1.0-2.0-preview2-2017-06-jessie"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/kitchensink",
               "tags": [
-                "1.0-2.0-preview1-2017-05-nanoserver",
-                "1.0-2.0-preview1-2017-05-nanoserver-$(nanoServerVersion)"
+                "1.0-2.0-preview2-2017-06-nanoserver",
+                "1.0-2.0-preview2-2017-06-nanoserver-$(nanoServerVersion)"
               ]
             }
           }

--- a/manifest.json
+++ b/manifest.json
@@ -5,10 +5,10 @@
   "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.testrunner.linux .",
-      "/bin/bash -c \"docker run --add-host dockerhost:$DOCKER_HOST_IP -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/test.ps1 microsoft dockerhost -Nightly\""
+      "/bin/bash -c \"docker run --add-host dockerhost:$DOCKER_HOST_IP -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/test.ps1 microsoft dockerhost\""
     ],
     "windows": [
-      "powershell -NoProfile -Command .\\test\\test.ps1 microsoft -Nightly"
+      "powershell -NoProfile -Command .\\test\\test.ps1 microsoft"
     ]
   },
   "repos": [

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -124,6 +124,7 @@ Get-ChildItem (Join-Paths $PSScriptRoot ("..", "*", $image_os, "sdk", "Dockerfil
                 WaitForSuccess "http://${ip}:${host_port}"
             }
             finally {
+                exec docker logs $app_container_name
                 exec docker rm -f $app_container_name
             }
         }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -4,7 +4,7 @@ param(
     # Set to Docker host IP if running within a container
     [string]$HostIP='localhost',
     # Set if testing nightly images
-    [switch]$Nightly
+    [switch]$Nightly=$true
 )
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
Part of #242 

Changes:
 - update all images on 'dev' to microsoft/dotnet-nightly
 - update 2.0 base images to preview2
 - nanoserver: update git to latest 2.13.1
 - install the latest preview2 build from aspnetcore-ci-release
