### PR TITLE
Update latest to 2.0 and drop preview3 from the 2.0 tags from daily builds

### DIFF
--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -12,17 +12,17 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 - `1.1.2`, `1.1`, `1`, `latest`
     - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/sdk/Dockerfile)
     - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver/sdk/Dockerfile)
-- `2.0.0-preview3`, `2.0`, `2`
-    - [`2.0.0-preview3-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
-    - [`2.0.0-preview3-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/sdk/Dockerfile)
-- [`2.0.0-preview3-jessie`, `2.0-jessie`, `2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/sdk/Dockerfile)
+- `2.0.0`, `2.0`, `2`
+    - [`2.0.0-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
+    - [`2.0.0-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/sdk/Dockerfile)
+- [`2.0.0-jessie`, `2.0-jessie`, `2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/sdk/Dockerfile)
 - `1.0-1.1-2017-05`, `1.0-1.1` (designed for CI builds)
     - [`1.0-1.1-2017-05-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/kitchensink/Dockerfile)
     - [`1.0-1.1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver/kitchensink/Dockerfile)
-- `1.0-2.0-preview3-2017-07`, `1.0-2.0-preview3` (designed for CI builds)
-    - [`1.0-2.0-preview3-2017-07-stretch` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/kitchensink/Dockerfile)
-    - [`1.0-2.0-preview3-2017-07-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/kitchensink/Dockerfile)
-- [`1.0-2.0-preview3-2017-07-jessie`, `1.0-2-0-preview3-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/kitchensink/Dockerfile)
+- `1.0-2.0-2017-08`, `1.0-2.0` (designed for CI builds)
+    - [`1.0-2.0-2017-08-stretch` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/kitchensink/Dockerfile)
+    - [`1.0-2.0-2017-08-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/kitchensink/Dockerfile)
+- [`1.0-2.0-2017-08-jessie`, `1.0-2-0-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/kitchensink/Dockerfile)
 
 ## What is ASP.NET Core?
 
@@ -36,7 +36,7 @@ This image contains:
 - [Bower](https://bower.io/)
 - [Gulp](http://gulpjs.com/)
 
-The CI Image (`1.0-1.1`) contains both the 1.0 and 1.1 pre-restored packages. It is intended for when you have a solution containing both 1.1.x and 1.0.x projects and want to build them all in the same container, gaining advantage of the pre-restored packages. Because it has an extra set of packages it is bigger than the other, more focused, images.
+The CI Image (`1.0-2.0`) contains the 1.0, 1.1, and 2.0 pre-restored packages. It is intended for when you have a solution containing both 2.x and 1.x projects and want to build them all in the same container, gaining advantage of the pre-restored packages. Because it has an extra set of packages it is bigger than the other, more focused, images.
 
 ## Related images
 

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -15,10 +15,10 @@ These images contain the runtime only. Use [`microsoft/aspnetcore-build-nightly`
 - `1.1.2`, `1.1`, `1`
     - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/runtime/Dockerfile)
     - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver/runtime/Dockerfile)
-- `2.0.0-preview3`, `2.0`, `2`
-    - [`2.0.0-preview3-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
-    - [`2.0.0-preview3-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/runtime/Dockerfile)
-- [`2.0.0-preview3-jessie`, '2.0-jessie', '2-jessie' (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/runtime/Dockerfile)
+- `2.0.0`, `2.0`, `2`
+    - [`2.0.0-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
+    - [`2.0.0-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver/runtime/Dockerfile)
+- [`2.0.0-jessie`, '2.0-jessie', '2-jessie' (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/runtime/Dockerfile)
 
 ## What is ASP.NET Core?
 

--- a/manifest.json
+++ b/manifest.json
@@ -42,8 +42,7 @@
           "sharedTags": [
             "1.1.2",
             "1.1",
-            "1",
-            "latest"
+            "1"
           ],
           "platforms": {
             "linux": {
@@ -63,22 +62,23 @@
         },
         {
           "sharedTags": [
-            "2.0.0-preview3",
+            "2.0.0",
             "2.0",
-            "2"
+            "2",
+            "latest"
           ],
           "platforms": {
             "linux": {
               "dockerfile": "2.0/stretch/runtime",
               "tags": [
-                "2.0.0-preview3-stretch"
+                "2.0.0-stretch"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/runtime",
               "tags": [
-                "2.0.0-preview3-nanoserver",
-                "2.0.0-preview3-nanoserver-$(nanoServerVersion)"
+                "2.0.0-nanoserver",
+                "2.0.0-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -88,7 +88,7 @@
             "linux": {
               "dockerfile": "2.0/jessie/runtime",
               "tags": [
-                "2.0.0-preview3-jessie",
+                "2.0.0-jessie",
                 "2.0-jessie",
                 "2-jessie"
               ]
@@ -127,8 +127,7 @@
           "sharedTags": [
             "1.1.2",
             "1.1",
-            "1",
-            "latest"
+            "1"
           ],
           "platforms": {
             "linux": {
@@ -148,22 +147,23 @@
         },
         {
           "sharedTags": [
-            "2.0.0-preview3",
+            "2.0.0",
             "2.0",
-            "2"
+            "2",
+            "latest"
           ],
           "platforms": {
             "linux": {
               "dockerfile": "2.0/stretch/sdk",
               "tags": [
-                "2.0.0-preview3-stretch"
+                "2.0.0-stretch"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/sdk",
               "tags": [
-                "2.0.0-preview3-nanoserver",
-                "2.0.0-preview3-nanoserver-$(nanoServerVersion)"
+                "2.0.0-nanoserver",
+                "2.0.0-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -173,7 +173,7 @@
             "linux": {
               "dockerfile": "2.0/jessie/sdk",
               "tags": [
-                "2.0.0-preview3-jessie",
+                "2.0.0-jessie",
                 "2.0-jessie",
                 "2-jessie"
               ]
@@ -203,22 +203,21 @@
         },
         {
           "sharedTags": [
-            "1.0-2.0-preview3-2017-07",
-            "1.0-2.0-preview3",
+            "1.0-2.0-2017-08",
             "1.0-2.0"
           ],
           "platforms": {
             "linux": {
               "dockerfile": "2.0/stretch/kitchensink",
               "tags": [
-                "1.0-2.0-preview3-2017-07-stretch"
+                "1.0-2.0-2017-08-stretch"
               ]
             },
             "windows": {
               "dockerfile": "2.0/nanoserver/kitchensink",
               "tags": [
-                "1.0-2.0-preview3-2017-07-nanoserver",
-                "1.0-2.0-preview3-2017-07-nanoserver-$(nanoServerVersion)"
+                "1.0-2.0-2017-08-nanoserver",
+                "1.0-2.0-2017-08-nanoserver-$(nanoServerVersion)"
               ]
             }
           }
@@ -228,8 +227,8 @@
             "linux": {
               "dockerfile": "2.0/jessie/kitchensink",
               "tags": [
-                "1.0-2.0-preview3-2017-07-jessie",
-                "1.0-2.0-preview3-jessie"
+                "1.0-2.0-2017-08-jessie",
+                "1.0-2.0-jessie"
               ]
             }
           }


### PR DESCRIPTION
Update tags on `microsoft/aspnetcore-nightly` and `microsoft/aspnetcore-build-nightly` to match what will eventually ship when 2.0 RTMs.

