### PR TITLE
Update the supported tags section to match microsoft/dotnet's layout

### DIFF
--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -4,25 +4,23 @@ ASP.NET Core Build Docker Image
 
 This repository contains images that are used to compile/publish ASP.NET Core applications inside the container. This is different to compiling an ASP.NET Core application and then adding the compiled output to an image, which is what you would do when using the [microsoft/aspnetcore](https://hub.docker.com/r/microsoft/aspnetcore/) image. These Dockerfiles use the [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) image as its base.
 
-## Supported tags
+# Supported Linux amd64 tags
 
-- `1.0.5`, `1.0`, `lts`
-    - [`1.0.5-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
-    - [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
-- `1.1.2`, `1.1`, `1`
-    - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-    - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
-- `2.0.0`, `2.0`, `2`, `latest`
-    - [`2.0.0-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
-    - [`2.0.0-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
-- [`2.0.0-jessie`, `2.0-jessie`, `2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
-- `1.0-1.1-2017-05`, `1.0-1.1` (designed for CI builds)
-    - [`1.0-1.1-2017-05-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
-    - [`1.0-1.1-2017-05-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
-- `1.0-2.0-2017-08`, `1.0-2.0` (designed for CI builds)
-    - [`1.0-2.0-2017-08-stretch` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
-    - [`1.0-2.0-2017-08-nanoserver` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
-- [`1.0-2.0-2017-08-jessie`, `1.0-2-0-jessie` (designed for CI builds), (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
+- [`1.0.5-jessie`, `1.0.5`, `1.0`, `lts` (*1.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
+- [`1.1.2-jessie`, `1.1.2`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
+- [`2.0.0-stretch`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.0-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- [`1.0-1.1-jessie`, `1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
+- [`1.0-2.0-stretch`, `1.0-2.0` (*2.0/stretch/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
+- [`1.0-2.0-jessie` (*2.0/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
+
+# Supported Windows amd64 tags
+
+- [`1.0.5-nanoserver`, `1.0.5`, `1.0`, `lts` (*1.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
+- [`1.1.2-nanoserver`, `1.1.2`, `1.1`, `1` (*1.1/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
+- [`2.0.0-nanoserver`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
+- [`1.0-1.1-nanoserver`, `1.0-1.1` (*1.1/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
+- [`1.0-2.0-nanoserver`, `1.0-2.0` (*2.0/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
 
 ## What is ASP.NET Core?
 

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -7,18 +7,23 @@ This repository contains images for running published ASP.NET Core applications.
 
 These images contain the runtime only. Use [`microsoft/aspnetcore-build`](https://hub.docker.com/r/microsoft/aspnetcore-build/) to build ASP.NET Core apps inside the container.
 
-## Supported tags
+# Supported Linux amd64 tags
 
-- `1.0.5`, `1.0`, `lts`
-    - [`1.0.5-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)
-    - [`1.0.5-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/runtime/Dockerfile)
-- `1.1.2`, `1.1`, `1`
-    - [`1.1.2-jessie` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/runtime/Dockerfile)
-    - [`1.1.2-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/runtime/Dockerfile)
-- `2.0.0`, `2.0`, `2`, `latest`
-    - [`2.0.0-stretch` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/runtime/Dockerfile)
-    - [`2.0.0-nanoserver` (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/runtime/Dockerfile)
-- [`2.0.0-jessie`, '2.0-jessie', '2-jessie' (*Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
+- [`1.0.5-jessie`, `1.0.5`, `1.0`, `lts` (*1.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
+- [`1.1.2-jessie`, `1.1.2`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
+- [`2.0.0-stretch`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.0-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- [`1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
+- [`1.0-2.0` (*2.0/stretch/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
+- [`1.0-2.0-jessie` (*2.0/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
+
+# Supported Windows amd64 tags
+
+- [`1.0.5-nanoserver`, `1.0.5`, `1.0`, `lts` (*1.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
+- [`1.1.2-nanoserver`, `1.1.2`, `1.1`, `1` (*1.1/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
+- [`2.0.0-nanoserver`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
+- [`1.0-1.1` (*1.1/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
+- [`1.0-2.0` (*2.0/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
 
 ## What is ASP.NET Core?
 

--- a/manifest.json
+++ b/manifest.json
@@ -208,22 +208,30 @@
         },
         {
           "sharedTags": {
-            "1.0-1.1-2017-05": {},
-            "1.0-1.1": {}
+            "1.0-1.1": {},
+            "1.0-1.1-2017-05": {
+              "isUndocumented": true
+            }
           },
           "platforms": [
             {
               "dockerfile": "1.1/jessie/kitchensink",
               "os": "linux",
               "tags": {
-                "1.0-1.1-2017-05-jessie": {}
+                "1.0-1.1-jessie": {},
+                "1.0-1.1-2017-05-jessie": {
+                  "isUndocumented": true
+                }
               }
             },
             {
               "dockerfile": "1.1/nanoserver/kitchensink",
               "os": "windows",
               "tags": {
-                "1.0-1.1-2017-05-nanoserver": {},
+                "1.0-1.1-nanoserver": {},
+                "1.0-1.1-2017-05-nanoserver": {
+                  "isUndocumented": true
+                },
                 "1.0-1.1-2017-05-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 }
@@ -233,22 +241,30 @@
         },
         {
           "sharedTags": {
-            "1.0-2.0-2017-08": {},
-            "1.0-2.0": {}
+            "1.0-2.0": {},
+            "1.0-2.0-2017-08": {
+              "isUndocumented": true
+            }
           },
           "platforms": [
             {
               "dockerfile": "2.0/stretch/kitchensink",
               "os": "linux",
               "tags": {
-                "1.0-2.0-2017-08-stretch": {}
+                "1.0-2.0-stretch": {},
+                "1.0-2.0-2017-08-stretch": {
+                  "isUndocumented": true
+                }
               }
             },
             {
               "dockerfile": "2.0/nanoserver/kitchensink",
               "os": "windows",
               "tags": {
-                "1.0-2.0-2017-08-nanoserver": {},
+                "1.0-2.0-nanoserver": {},
+                "1.0-2.0-2017-08-nanoserver": {
+                  "isUndocumented": true
+                },
                 "1.0-2.0-2017-08-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 }
@@ -262,8 +278,10 @@
               "dockerfile": "2.0/jessie/kitchensink",
               "os": "linux",
               "tags": {
-                "1.0-2.0-2017-08-jessie": {},
-                "1.0-2.0-jessie": {}
+                "1.0-2.0-jessie": {},
+                "1.0-2.0-2017-08-jessie": {
+                  "isUndocumented": true
+                }
               }
             }
           ]

--- a/scripts/GenerateTags.ps1
+++ b/scripts/GenerateTags.ps1
@@ -1,0 +1,29 @@
+#!/usr/bin/env powershell
+#requires -version 4
+param(
+    [Parameter()]
+    [Alias('b')]
+    [string]$Branch
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 1
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (!$Branch) {
+    $Branch = "$(& git rev-parse --abbrev-ref HEAD)"
+}
+
+if (!$Branch) {
+    Write-Warning 'Could not automatically determine branch. Falling back to "master". Add -Branch <BRANCH> to override'
+    $Branch = 'master'
+}
+
+
+& docker run --rm `
+    -v /var/run/docker.sock:/var/run/docker.sock `
+    -v "${repoRoot}:/repo" `
+    -w /repo `
+    microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316 `
+    generateTagsReadme `
+    "https://github.com/aspnet/aspnet-docker/blob/${Branch}"


### PR DESCRIPTION
Generated the tags sections using docker-tools to match microsoft/dotnet.

Also, added `-$(os)` tags for the kitchensink variant, and unlisted the date-specific tags. We've never encouraged their usage anyways.