### PR TITLE
Update the aspnetcore-build images to contain the 2.0.2 .NET Core SDK

### DIFF
--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk-jessie
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk-jessie
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/kitchensink/Dockerfile
+++ b/2.0/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-2.0.2-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2-10.0.14393.1715
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/kitchensink/Dockerfile
+++ b/2.0/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-nanoserver-10.0.14393.1715
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-2.0.2-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2-10.0.14393.1715
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-nanoserver-10.0.14393.1715
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk-stretch
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk-stretch
+FROM microsoft/dotnet:2.0.0-sdk-2.0.2-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -8,8 +8,8 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 - [`1.0.7-jessie`, `1.0.7`, `1.0`, `lts` (*1.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/sdk/Dockerfile)
 - [`1.1.4-jessie`, `1.1.4`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`2.0.0-stretch`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
-- [`2.0.0-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- [`2.0.2-stretch`, `2.0.2`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.2-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
 - [`1.0-1.1-jessie`, `1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
 - [`1.0-2.0-stretch`, `1.0-2.0` (*2.0/stretch/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
 - [`1.0-2.0-jessie` (*2.0/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
@@ -18,7 +18,7 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 - [`1.0.7-nanoserver`, `1.0.7`, `1.0`, `lts` (*1.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver/sdk/Dockerfile)
 - [`1.1.4-nanoserver`, `1.1.4`, `1.1`, `1` (*1.1/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/sdk/Dockerfile)
-- [`2.0.0-nanoserver`, `2.0.0`, `2.0`, `2`, `latest` (*2.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
+- [`2.0.2-nanoserver`, `2.0.2`, `2.0`, `2`, `latest` (*2.0/nanoserver/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/sdk/Dockerfile)
 - [`1.0-1.1-nanoserver`, `1.0-1.1` (*1.1/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver/kitchensink/Dockerfile)
 - [`1.0-2.0-nanoserver`, `1.0-2.0` (*2.0/nanoserver/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver/kitchensink/Dockerfile)
 

--- a/manifest.json
+++ b/manifest.json
@@ -168,7 +168,7 @@
         },
         {
           "sharedTags": {
-            "2.0.0": {},
+            "2.0.2": {},
             "2.0": {},
             "2": {},
             "latest": {}
@@ -178,15 +178,15 @@
               "dockerfile": "2.0/stretch/sdk",
               "os": "linux",
               "tags": {
-                "2.0.0-stretch": {}
+                "2.0.2-stretch": {}
               }
             },
             {
               "dockerfile": "2.0/nanoserver/sdk",
               "os": "windows",
               "tags": {
-                "2.0.0-nanoserver": {},
-                "2.0.0-nanoserver-$(nanoServerVersion)": {
+                "2.0.2-nanoserver": {},
+                "2.0.2-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 }
               }
@@ -199,7 +199,7 @@
               "dockerfile": "2.0/jessie/sdk",
               "os": "linux",
               "tags": {
-                "2.0.0-jessie": {},
+                "2.0.2-jessie": {},
                 "2.0-jessie": {},
                 "2-jessie": {}
               }
@@ -242,7 +242,7 @@
         {
           "sharedTags": {
             "1.0-2.0": {},
-            "1.0-2.0-2017-09": {
+            "1.0-2.0-2017-10": {
               "isUndocumented": true
             }
           },
@@ -252,7 +252,7 @@
               "os": "linux",
               "tags": {
                 "1.0-2.0-stretch": {},
-                "1.0-2.0-2017-09-stretch": {
+                "1.0-2.0-2017-10-stretch": {
                   "isUndocumented": true
                 }
               }
@@ -262,10 +262,10 @@
               "os": "windows",
               "tags": {
                 "1.0-2.0-nanoserver": {},
-                "1.0-2.0-2017-09-nanoserver": {
+                "1.0-2.0-2017-10-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.0-2.0-2017-09-nanoserver-$(nanoServerVersion)": {
+                "1.0-2.0-2017-10-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 }
               }
@@ -279,7 +279,7 @@
               "os": "linux",
               "tags": {
                 "1.0-2.0-jessie": {},
-                "1.0-2.0-2017-09-jessie": {
+                "1.0-2.0-2017-10-jessie": {
                   "isUndocumented": true
                 }
               }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -198,7 +198,12 @@ try
                     $version = $_.dockerfile.Substring(0, 3)
                     $sdk_tag_info = $_.tags | % { $_.PSobject.Properties } | select -first 1
                     $sdk_tag = "${repoName}:$($sdk_tag_info.name)"
-                    $runtime_tag = $sdk_tag -replace '-build',''
+                    $runtime_tag = switch ($version) {
+                        # map the 2.0.2 sdk to the 2.0.0 runtime
+                        "2.0" { $sdk_tag -replace '2.0.2','2.0.0' }
+                        Default { $sdk_tag }
+                    }
+                    $runtime_tag = $runtime_tag -replace '-build',''
 
                     test_image $version $sdk_tag $runtime_tag
                 }


### PR DESCRIPTION
CI is expected to fail until the new base images become available. See dotnet/dotnet-docker#307.

Resolves #311 