### PR TITLE
Stop producing full-qualified nanoserver tags

### DIFF
--- a/1.0/nanoserver/runtime/Dockerfile
+++ b/1.0/nanoserver/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.0.7-runtime-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:1.0.7-runtime-nanoserver
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.0/nanoserver/sdk/Dockerfile
+++ b/1.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.0.7-sdk-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:1.0.7-sdk-nanoserver
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver/kitchensink/Dockerfile
+++ b/1.1/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.4-sdk-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:1.1.4-sdk-nanoserver
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver/runtime/Dockerfile
+++ b/1.1/nanoserver/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.4-runtime-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:1.1.4-runtime-nanoserver
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver/sdk/Dockerfile
+++ b/1.1/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.4-sdk-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:1.1.4-sdk-nanoserver
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/kitchensink/Dockerfile
+++ b/2.0/nanoserver/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-runtime-nanoserver-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-runtime-nanoserver
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2-10.0.14393.1715
+FROM microsoft/dotnet:2.0.0-sdk-nanoserver-2.0.2
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,4 @@
 {
-  "tagVariables": {
-    "nanoServerVersion": "10.0.14393.1715"
-  },
   "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.testrunner.linux .",
@@ -34,10 +31,7 @@
               "dockerfile": "1.0/nanoserver/runtime",
               "os": "windows",
               "tags": {
-                "1.0.7-nanoserver": {},
-                "1.0.7-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "1.0.7-nanoserver": {}
               }
             }
           ]
@@ -60,10 +54,7 @@
               "dockerfile": "1.1/nanoserver/runtime",
               "os": "windows",
               "tags": {
-                "1.1.4-nanoserver": {},
-                "1.1.4-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "1.1.4-nanoserver": {}
               }
             }
           ]
@@ -87,10 +78,7 @@
               "dockerfile": "2.0/nanoserver/runtime",
               "os": "windows",
               "tags": {
-                "2.0.0-nanoserver": {},
-                "2.0.0-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "2.0.0-nanoserver": {}
               }
             }
           ]
@@ -132,10 +120,7 @@
               "dockerfile": "1.0/nanoserver/sdk",
               "os": "windows",
               "tags": {
-                "1.0.7-nanoserver": {},
-                "1.0.7-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "1.0.7-nanoserver": {}
               }
             }
           ]
@@ -158,10 +143,7 @@
               "dockerfile": "1.1/nanoserver/sdk",
               "os": "windows",
               "tags": {
-                "1.1.4-nanoserver": {},
-                "1.1.4-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "1.1.4-nanoserver": {}
               }
             }
           ]
@@ -185,10 +167,7 @@
               "dockerfile": "2.0/nanoserver/sdk",
               "os": "windows",
               "tags": {
-                "2.0.2-nanoserver": {},
-                "2.0.2-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "2.0.2-nanoserver": {}
               }
             }
           ]
@@ -231,9 +210,6 @@
                 "1.0-1.1-nanoserver": {},
                 "1.0-1.1-2017-09-nanoserver": {
                   "isUndocumented": true
-                },
-                "1.0-1.1-2017-09-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
                 }
               }
             }
@@ -263,9 +239,6 @@
               "tags": {
                 "1.0-2.0-nanoserver": {},
                 "1.0-2.0-2017-10-nanoserver": {
-                  "isUndocumented": true
-                },
-                "1.0-2.0-2017-10-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 }
               }


### PR DESCRIPTION
See https://github.com/dotnet/dotnet-docker/issues/312. These were undocumented anyways, and increased our maintenance work. Patches to nano should now automatically roll up from microsoft/dotnet into the aspnetcore images.

cc @ravimeda