### PR TITLE
Get specific version of PowerShell in Dockerfile.testrunner.linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   fast_finish: true
 before_install:
-  - bash <(curl -fsSL https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/download.sh)
+  - bash <(curl -fsSL https://raw.githubusercontent.com/PowerShell/PowerShell/v6.0.0-beta.6/tools/download.sh)
 install:
   - ./build.ps1 -Folder $folder_filter
 before_script:

--- a/test/Dockerfile.testrunner.linux
+++ b/test/Dockerfile.testrunner.linux
@@ -3,19 +3,32 @@
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File test/test.ps1 <test.ps1 args>
 
 FROM ubuntu:16.04
+
+# Install Docker
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
         curl \
-        docker.io \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
+        software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        powershell \
+        docker-ce \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR repo
+# Install PowerShell
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libicu55 \
+        libcurl3 \
+        libunwind8 \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -o powershell.deb -ssL \
+        https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb \
+    && dpkg -i powershell.deb \
+    && rm -f powershell.deb
+
+WORKDIR test
 COPY . .


### PR DESCRIPTION
Porting changes from (https://github.com/dotnet/dotnet-docker/commit/d689737f7ecd5c60c54acd57865f55e4fee3a02e#diff-2a94d6d66048b505f6052556c0325bd7) to ensure a specified version of PowerShell is available in the image. This avoids build breaks due to changes in PowerShell as discussed in https://github.com/aspnet/aspnet-docker/pull/319
