### PR TITLE
Update images for the 1.1.6 and 2.0.4 release

### DIFF
--- a/1.1/jessie/kitchensink/Dockerfile
+++ b/1.1/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.5-sdk
+FROM microsoft/dotnet:1.1.5-sdk-1.1.6
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/jessie/kitchensink/packagescache.csproj
+++ b/1.1/jessie/kitchensink/packagescache.csproj
@@ -144,10 +144,10 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
@@ -157,26 +157,26 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Localization.Routing" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2" />
@@ -196,11 +196,11 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="1.1.2" />

--- a/1.1/jessie/runtime/Dockerfile
+++ b/1.1/jessie/runtime/Dockerfile
@@ -7,7 +7,7 @@ ENV ASPNETCORE_URLS http://+:80
 ENV DOTNET_HOSTING_OPTIMIZATION_CACHE /packagescache
 
 # set up package cache and other tools
-RUN for version in '1.1.2' '1.1.3' '1.1.4' '1.1.5'; do \
+RUN for version in '1.1.2' '1.1.3' '1.1.4' '1.1.5' '1.1.6'; do \
         curl -o /tmp/aspnetcore.cache.$version.tar.gz \
             https://dist.asp.net/packagecache/$version/debian.8-x64/aspnetcore.cache.tar.gz \
         && mkdir -p /packagescache && cd /packagescache \

--- a/1.1/jessie/sdk/Dockerfile
+++ b/1.1/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.5-sdk
+FROM microsoft/dotnet:1.1.5-sdk-1.1.6
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/jessie/sdk/packagescache.csproj
+++ b/1.1/jessie/sdk/packagescache.csproj
@@ -144,10 +144,10 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
@@ -157,26 +157,26 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Localization.Routing" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2" />
@@ -196,11 +196,11 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="1.1.2" />

--- a/1.1/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/1.1/nanoserver-sac2016/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.5-sdk-nanoserver-sac2016
+FROM microsoft/dotnet:1.1.5-sdk-1.1.6-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver-sac2016/kitchensink/packagescache.csproj
+++ b/1.1/nanoserver-sac2016/kitchensink/packagescache.csproj
@@ -144,10 +144,10 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
@@ -157,26 +157,26 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Localization.Routing" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2" />
@@ -196,11 +196,11 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="1.1.2" />

--- a/1.1/nanoserver-sac2016/runtime/Dockerfile
+++ b/1.1/nanoserver-sac2016/runtime/Dockerfile
@@ -8,7 +8,7 @@ ENV ASPNETCORE_URLS http://+:80
 ENV DOTNET_HOSTING_OPTIMIZATION_CACHE C:/packagecache
 
 # set up package caches
-RUN @('1.1.0', '1.1.1', '1.1.2', '1.1.3', '1.1.4', '1.1.5') | % { `
+RUN @('1.1.0', '1.1.1', '1.1.2', '1.1.3', '1.1.4', '1.1.5', '1.1.6') | % { `
         $downloadUrl = \"https://dist.asp.net/packagecache/${_}/win7-x64/aspnetcore.cache.zip\"; `
         $fileName = \"cache${_}.zip\"; `
         Write-Host \"Downloading and extracting $downloadUrl\"; `

--- a/1.1/nanoserver-sac2016/sdk/Dockerfile
+++ b/1.1/nanoserver-sac2016/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:1.1.5-sdk-nanoserver-sac2016
+FROM microsoft/dotnet:1.1.5-sdk-1.1.6-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/1.1/nanoserver-sac2016/sdk/packagescache.csproj
+++ b/1.1/nanoserver-sac2016/sdk/packagescache.csproj
@@ -144,10 +144,10 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
@@ -157,26 +157,26 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Localization.Routing" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Host" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2" />
@@ -196,11 +196,11 @@
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="1.1.2" />

--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-jessie
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
-ENV NETCORE_1_0_VERSION 1.0.8
-ENV NETCORE_1_1_VERSION 1.1.5
+ENV NETCORE_1_0_RUNTIME_VERSION 1.0.8
+ENV NETCORE_1_1_RUNTIME_VERSION 1.1.5
 ENV NODE_VERSION 6.11.3
 ENV ASPNETCORE_PKG_VERSION 2.0.3
 
@@ -42,8 +42,8 @@ RUN buildDeps='xz-utils' \
 
 # Install the 1.x runtimes
 RUN for url in \
-      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_0_VERSION}/dotnet-debian-x64.${NETCORE_1_0_VERSION}.tar.gz" \
-      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_1_VERSION}/dotnet-debian-x64.${NETCORE_1_1_VERSION}.tar.gz"; \
+      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_0_RUNTIME_VERSION}/dotnet-debian-x64.${NETCORE_1_0_RUNTIME_VERSION}.tar.gz" \
+      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_1_RUNTIME_VERSION}/dotnet-debian-x64.${NETCORE_1_1_RUNTIME_VERSION}.tar.gz"; \
     do \
       echo "Downloading and installing from $url" \
       && curl -SL $url --output /tmp/dotnet.tar.gz \

--- a/2.0/jessie/runtime/Dockerfile
+++ b/2.0/jessie/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-runtime-jessie
+FROM microsoft/dotnet:2.0.4-runtime-jessie
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-jessie
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -6,8 +6,8 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # versions of stuff
-ENV NETCORE_1_0_VERSION 1.0.8
-ENV NETCORE_1_1_VERSION 1.1.5
+ENV NETCORE_1_0_RUNTIME_VERSION 1.0.8
+ENV NETCORE_1_1_RUNTIME_VERSION 1.1.5
 
 # Retrieve node and git
 ENV NODE_VERSION 6.11.3
@@ -22,8 +22,8 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force git.zip
 
 # Retrieve additional runtimes
-RUN @(\"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_0_VERSION}/dotnet-win-x64.${env:NETCORE_1_0_VERSION}.zip\", `
-     \"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_1_VERSION}/dotnet-win-x64.${env:NETCORE_1_1_VERSION}.zip\" ) `
+RUN @(\"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_0_RUNTIME_VERSION}/dotnet-win-x64.${env:NETCORE_1_0_RUNTIME_VERSION}.zip\", `
+     \"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_1_RUNTIME_VERSION}/dotnet-win-x64.${env:NETCORE_1_1_RUNTIME_VERSION}.zip\" ) `
      | % { `
         Invoke-WebRequest $_ -UseBasicParsing -OutFile dotnet.zip; `
         # Ignore errors and don't use -Force. We want to keep the existing dotnet.exe instead of overwriting `
@@ -38,7 +38,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 
 
 # Kitchen Sink image
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-1709
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-nanoserver-1709
 
 # Note: Kitchen Sink image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-1709/runtime/Dockerfile
+++ b/2.0/nanoserver-1709/runtime/Dockerfile
@@ -15,7 +15,7 @@ RUN  @('2.0.0', '2.0.3') | % { `
     }
 
 # Runtime image
-FROM microsoft/dotnet:2.0.3-runtime-nanoserver-1709
+FROM microsoft/dotnet:2.0.4-runtime-nanoserver-1709
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -19,7 +19,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
 
 
 # Build image
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-1709
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-nanoserver-1709
 
 # Note: Build image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -1,11 +1,11 @@
 # escape=`
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
 ENV NODE_VERSION 6.11.3
-ENV NETCORE_1_0_VERSION 1.0.8
-ENV NETCORE_1_1_VERSION 1.1.5
+ENV NETCORE_1_0_RUNTIME_VERSION 1.0.8
+ENV NETCORE_1_1_RUNTIME_VERSION 1.1.5
 ENV ASPNETCORE_PKG_VERSION 2.0.3
 
 # Install node, bower, and git
@@ -21,8 +21,8 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '/nodejs' + ';' + $Env:ProgramFiles + '/git/cmd')
 
-RUN @(\"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_0_VERSION}/dotnet-win-x64.${env:NETCORE_1_0_VERSION}.zip\", `
-     \"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_1_VERSION}/dotnet-win-x64.${env:NETCORE_1_1_VERSION}.zip\" ) `
+RUN @(\"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_0_RUNTIME_VERSION}/dotnet-win-x64.${env:NETCORE_1_0_RUNTIME_VERSION}.zip\", `
+     \"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${env:NETCORE_1_1_RUNTIME_VERSION}/dotnet-win-x64.${env:NETCORE_1_1_RUNTIME_VERSION}.zip\" ) `
      | % { `
         Invoke-WebRequest $_ -UseBasicParsing -OutFile dotnet.zip; `
         # Ignore errors and don't use -Force. We want to keep the existing dotnet.exe instead of overwriting `

--- a/2.0/nanoserver-sac2016/runtime/Dockerfile
+++ b/2.0/nanoserver-sac2016/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.3-runtime-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.4-runtime-nanoserver-sac2016
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -1,10 +1,10 @@
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-stretch
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
 ENV NODE_VERSION 6.11.3
-ENV NETCORE_1_0_VERSION 1.0.8
-ENV NETCORE_1_1_VERSION 1.1.5
+ENV NETCORE_1_0_RUNTIME_VERSION 1.0.8
+ENV NETCORE_1_1_RUNTIME_VERSION 1.1.5
 ENV ASPNETCORE_PKG_VERSION 2.0.3
 
 RUN set -x \
@@ -46,8 +46,8 @@ RUN buildDeps='xz-utils' \
 
 # Install the 1.x runtimes
 RUN for url in \
-      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_0_VERSION}/dotnet-debian-x64.${NETCORE_1_0_VERSION}.tar.gz" \
-      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_1_VERSION}/dotnet-debian-x64.${NETCORE_1_1_VERSION}.tar.gz"; \
+      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_0_RUNTIME_VERSION}/dotnet-debian-x64.${NETCORE_1_0_RUNTIME_VERSION}.tar.gz" \
+      "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/${NETCORE_1_1_RUNTIME_VERSION}/dotnet-debian-x64.${NETCORE_1_1_RUNTIME_VERSION}.tar.gz"; \
     do \
       echo "Downloading and installing from $url" \
       && curl -SL $url --output /tmp/dotnet.tar.gz \

--- a/2.0/stretch/runtime/Dockerfile
+++ b/2.0/stretch/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-runtime-stretch
+FROM microsoft/dotnet:2.0.4-runtime-stretch
 
 # set up network
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-2.1.2-stretch
+FROM microsoft/dotnet:2.0.4-sdk-2.1.3-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -6,26 +6,28 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 # Supported Linux amd64 tags
 
-- [`1.1.5-jessie`, `1.1.5`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`2.0.3-2.1.2-stretch`, `2.0-stretch`, `2.0.3-2.1.2`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
-- [`2.0.3-2.1.2-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- [`1.1.5-1.1.6-jessie`, `1.1.5-1.1.6`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
+- [`2.0.4-2.1.3-stretch`, `2.0-stretch`, `2.0.4-2.1.3`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.4-2.1.3-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
 - [`1.0-1.1-jessie`, `1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
 - [`1.0-2.0-stretch`, `1.0-2.0` (*2.0/stretch/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
 - [`1.0-2.0-jessie` (*2.0/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/kitchensink/Dockerfile)
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`2.0.3-2.1.2-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.3-2.1.2`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.0.4-2.1.3-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.4-2.1.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
 - [`1.0-2.0-nanoserver-1709`, `1.0-2.0` (*2.0/nanoserver-1709/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/kitchensink/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
-- [`1.1.5-nanoserver-sac2016`, `1.1.5`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.3-2.1.2-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.3-2.1.2`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`1.1.5-1.1.6-nanoserver-sac2016`, `1.1.5-1.1.6`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.4-2.1.3-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.4-2.1.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
 - [`1.0-1.1-nanoserver-sac2016`, `1.0-1.1` (*1.1/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/kitchensink/Dockerfile)
 - [`1.0-2.0-nanoserver-sac2016`, `1.0-2.0` (*2.0/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/kitchensink/Dockerfile)
 
 >**Note:** ASP.NET Core multi-arch tags, such as 2.0, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
+
+>**Note:** In images tagged with two versions in this pattern `A.B.C-X.Y.Z`, the first version `A.B.C` represents the .NET Core runtime version, and the second `X.Y.Z` represents the .NET Core SDK version.
 
 # What is ASP.NET Core?
 
@@ -122,4 +124,3 @@ docker run -it -v $(PWD):/app --workdir /app microsoft/aspnetcore-build bash -c 
 ```
 
 After this is completed, the application in the current directory will be published to the `bin/Release/PublishOutput` directory.
-

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -11,18 +11,18 @@ These images contain the runtime only. Use [`microsoft/aspnetcore-build`](https:
 
 - [`1.0.8-jessie`, `1.0.8`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)
 - [`1.1.5-jessie`, `1.1.5`, `1.1`, `1` (*1.1/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/runtime/Dockerfile)
-- [`2.0.3-stretch`, `2.0-stretch`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/runtime/Dockerfile)
-- [`2.0.3-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
+- [`2.0.4-stretch`, `2.0-stretch`, `2.0.4`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/runtime/Dockerfile)
+- [`2.0.4-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`2.0.3-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/runtime/Dockerfile)
+- [`2.0.4-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.4`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/runtime/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
 - [`1.0.8-nanoserver-sac2016`, `1.0.8`, `1.0` (*1.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver-sac2016/runtime/Dockerfile)
 - [`1.1.5-nanoserver-sac2016`, `1.1.5`, `1.1`, `1` (*1.1/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/runtime/Dockerfile)
-- [`2.0.3-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/runtime/Dockerfile)
+- [`2.0.4-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.4`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/runtime/Dockerfile)
 
 >**Note:** ASP.NET Core multi-arch tags, such as 2.0, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
 

--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
         },
         {
           "sharedTags": {
-            "2.0.3": {},
+            "2.0.4": {},
             "2.0": {},
             "2": {},
             "latest": {}
@@ -73,7 +73,7 @@
               "dockerfile": "2.0/stretch/runtime",
               "os": "linux",
               "tags": {
-                "2.0.3-stretch": {},
+                "2.0.4-stretch": {},
                 "2.0-stretch": {}
               }
             },
@@ -81,11 +81,8 @@
               "dockerfile": "2.0/nanoserver-sac2016/runtime",
               "os": "windows",
               "tags": {
-                "2.0.3-nanoserver-sac2016": {},
+                "2.0.4-nanoserver-sac2016": {},
                 "2.0-nanoserver-sac2016": {},
-                "2.0.3-nanoserver": {
-                  "isUndocumented": true
-                },
                 "2.0-nanoserver": {
                   "isUndocumented": true
                 }
@@ -96,7 +93,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.0.3-nanoserver-1709": {},
+                "2.0.4-nanoserver-1709": {},
                 "2.0-nanoserver-1709": {}
               }
             }
@@ -108,7 +105,7 @@
               "dockerfile": "2.0/jessie/runtime",
               "os": "linux",
               "tags": {
-                "2.0.3-jessie": {},
+                "2.0.4-jessie": {},
                 "2.0-jessie": {},
                 "2-jessie": {}
               }
@@ -123,7 +120,7 @@
       "images": [
         {
           "sharedTags": {
-            "1.1.5": {},
+            "1.1.5-1.1.6": {},
             "1.1": {},
             "1": {},
             "1.0": {
@@ -138,21 +135,21 @@
               "dockerfile": "1.1/jessie/sdk",
               "os": "linux",
               "tags": {
-                "1.1.5-jessie": {}
+                "1.1.5-1.1.6-jessie": {}
               }
             },
             {
               "dockerfile": "1.1/nanoserver-sac2016/sdk",
               "os": "windows",
               "tags": {
-                "1.1.5-nanoserver-sac2016": {}
+                "1.1.5-1.1.6-nanoserver-sac2016": {}
               }
             }
           ]
         },
         {
           "sharedTags": {
-            "2.0.3-2.1.2": {},
+            "2.0.4-2.1.3": {},
             "2.0": {},
             "2": {},
             "latest": {}
@@ -162,7 +159,7 @@
               "dockerfile": "2.0/stretch/sdk",
               "os": "linux",
               "tags": {
-                "2.0.3-2.1.2-stretch": {},
+                "2.0.4-2.1.3-stretch": {},
                 "2.0-stretch": {}
               }
             },
@@ -170,7 +167,7 @@
               "dockerfile": "2.0/nanoserver-sac2016/sdk",
               "os": "windows",
               "tags": {
-                "2.0.3-2.1.2-nanoserver-sac2016": {},
+                "2.0.4-2.1.3-nanoserver-sac2016": {},
                 "2.0-nanoserver-sac2016": {},
                 "2.0-nanoserver": {
                   "isUndocumented": true
@@ -182,7 +179,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.0.3-2.1.2-nanoserver-1709": {},
+                "2.0.4-2.1.3-nanoserver-1709": {},
                 "2.0-nanoserver-1709": {}
               }
             }
@@ -194,7 +191,7 @@
               "dockerfile": "2.0/jessie/sdk",
               "os": "linux",
               "tags": {
-                "2.0.3-2.1.2-jessie": {},
+                "2.0.4-2.1.3-jessie": {},
                 "2.0-jessie": {},
                 "2-jessie": {}
               }
@@ -204,7 +201,7 @@
         {
           "sharedTags": {
             "1.0-1.1": {},
-            "1.0-1.1-2017-11": {
+            "1.0-1.1-2017-12": {
               "isUndocumented": true
             }
           },
@@ -214,7 +211,7 @@
               "os": "linux",
               "tags": {
                 "1.0-1.1-jessie": {},
-                "1.0-1.1-2017-11-jessie": {
+                "1.0-1.1-2017-12-jessie": {
                   "isUndocumented": true
                 }
               }
@@ -227,7 +224,7 @@
                 "1.0-1.1-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.0-1.1-2017-11-nanoserver": {
+                "1.0-1.1-2017-12-nanoserver": {
                   "isUndocumented": true
                 }
               }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -205,6 +205,8 @@ try
                     $sdk_tag_info = $_.tags | % { $_.PSobject.Properties } | select -first 1
                     $sdk_tag = "${repoName}:$($sdk_tag_info.name)"
                     $runtime_tag = switch ($version) {
+                        # map the 1.1.5-1.1.6 sdk tags to the runtime tag name
+                        "1.1" { $sdk_tag -replace '-1.1.6','' }
                         # map the 2.0.4-2.1.3 sdk tags to the runtime tag name
                         "2.0" { $sdk_tag -replace '-2.1.3','' }
                         Default { $sdk_tag }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -205,8 +205,8 @@ try
                     $sdk_tag_info = $_.tags | % { $_.PSobject.Properties } | select -first 1
                     $sdk_tag = "${repoName}:$($sdk_tag_info.name)"
                     $runtime_tag = switch ($version) {
-                        # map the 2.0.3-2.1.2 sdk tags to the runtime tag name
-                        "2.0" { $sdk_tag -replace '-2.1.2','' }
+                        # map the 2.0.4-2.1.3 sdk tags to the runtime tag name
+                        "2.0" { $sdk_tag -replace '-2.1.3','' }
                         Default { $sdk_tag }
                     }
                     $runtime_tag = $runtime_tag -replace '-build',''


### PR DESCRIPTION
The package caches have not been verified yet so these images can't be built yet. I also need to update a few more tags and the readme.