### PR TITLE
Update the .NET Core SDK

### DIFF
--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-jessie
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-jessie
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -38,7 +38,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 
 
 # Kitchen Sink image
-FROM microsoft/dotnet:2.0.3-sdk-nanoserver-1709
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-1709
 
 # Note: Kitchen Sink image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -19,7 +19,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
 
 
 # Build image
-FROM microsoft/dotnet:2.0.3-sdk-nanoserver-1709
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-1709
 
 # Note: Build image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.3-sdk-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.3-sdk-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-stretch
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.3-sdk-stretch
+FROM microsoft/dotnet:2.0.3-sdk-2.1.2-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -7,7 +7,7 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 # Supported Linux amd64 tags
 
 - [`1.1.5-jessie`, `1.1.5`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`2.0.3-stretch`, `2.0-stretch`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.3-2.1.2-stretch`, `2.0-stretch`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
 - [`2.0.3-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
 - [`1.0-1.1-jessie`, `1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
 - [`1.0-2.0-stretch`, `1.0-2.0` (*2.0/stretch/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/kitchensink/Dockerfile)
@@ -15,13 +15,13 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`2.0.3-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.0.3-2.1.2-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
 - [`1.0-2.0-nanoserver-1709`, `1.0-2.0` (*2.0/nanoserver-1709/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/kitchensink/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
 - [`1.1.5-nanoserver-sac2016`, `1.1.5`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.3-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.3-2.1.2-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.3`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
 - [`1.0-1.1-nanoserver-sac2016`, `1.0-1.1` (*1.1/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/kitchensink/Dockerfile)
 - [`1.0-2.0-nanoserver-sac2016`, `1.0-2.0` (*2.0/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/kitchensink/Dockerfile)
 

--- a/manifest.json
+++ b/manifest.json
@@ -162,7 +162,7 @@
               "dockerfile": "2.0/stretch/sdk",
               "os": "linux",
               "tags": {
-                "2.0.3-stretch": {},
+                "2.0.3-2.1.2-stretch": {},
                 "2.0-stretch": {}
               }
             },
@@ -170,11 +170,8 @@
               "dockerfile": "2.0/nanoserver-sac2016/sdk",
               "os": "windows",
               "tags": {
-                "2.0.3-nanoserver-sac2016": {},
+                "2.0.3-2.1.2-nanoserver-sac2016": {},
                 "2.0-nanoserver-sac2016": {},
-                "2.0.3-nanoserver": {
-                  "isUndocumented": true
-                },
                 "2.0-nanoserver": {
                   "isUndocumented": true
                 }
@@ -185,7 +182,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.0.3-nanoserver-1709": {},
+                "2.0.3-2.1.2-nanoserver-1709": {},
                 "2.0-nanoserver-1709": {}
               }
             }
@@ -240,7 +237,7 @@
         {
           "sharedTags": {
             "1.0-2.0": {},
-            "1.0-2.0-2017-11": {
+            "1.0-2.0-2017-12": {
               "isUndocumented": true
             }
           },
@@ -250,7 +247,7 @@
               "os": "linux",
               "tags": {
                 "1.0-2.0-stretch": {},
-                "1.0-2.0-2017-11-stretch": {
+                "1.0-2.0-2017-12-stretch": {
                   "isUndocumented": true
                 }
               }
@@ -263,7 +260,7 @@
                 "1.0-2.0-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.0-2.0-2017-11-nanoserver": {
+                "1.0-2.0-2017-12-nanoserver": {
                   "isUndocumented": true
                 }
               }
@@ -274,7 +271,7 @@
               "osVersion": "1709",
               "tags": {
                 "1.0-2.0-nanoserver-1709": {},
-                "1.0-2.0-2017-11-nanoserver-1709": {
+                "1.0-2.0-2017-12-nanoserver-1709": {
                   "isUndocumented": true
                 }
               }
@@ -288,7 +285,7 @@
               "os": "linux",
               "tags": {
                 "1.0-2.0-jessie": {},
-                "1.0-2.0-2017-11-jessie": {
+                "1.0-2.0-2017-12-jessie": {
                   "isUndocumented": true
                 }
               }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -205,8 +205,8 @@ try
                     $sdk_tag_info = $_.tags | % { $_.PSobject.Properties } | select -first 1
                     $sdk_tag = "${repoName}:$($sdk_tag_info.name)"
                     $runtime_tag = switch ($version) {
-                        # map the 2.0.2 sdk to the 2.0.0 runtime
-                        "2.0" { $sdk_tag -replace '2.0.2','2.0.0' }
+                        # map the 2.0.3-2.1.2 sdk tags to the runtime tag name
+                        "2.0" { $sdk_tag -replace '-2.1.2','' }
                         Default { $sdk_tag }
                     }
                     $runtime_tag = $runtime_tag -replace '-build',''


### PR DESCRIPTION
React to https://github.com/dotnet/dotnet-docker/pull/350. SDK 2.1.2 was released with VS 15.5.

CI is expected to fail until the new base images are available on Docker Hub.

cc @JunTaoLuo