### PR TITLE
Use TLS1.2 when downloading from GitHub

### DIFF
--- a/1.1/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/1.1/nanoserver-sac2016/kitchensink/Dockerfile
@@ -13,7 +13,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/1.1/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/1.1/nanoserver-sac2016/kitchensink/Dockerfile
@@ -12,6 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip

--- a/1.1/nanoserver-sac2016/sdk/Dockerfile
+++ b/1.1/nanoserver-sac2016/sdk/Dockerfile
@@ -13,7 +13,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/1.1/nanoserver-sac2016/sdk/Dockerfile
+++ b/1.1/nanoserver-sac2016/sdk/Dockerfile
@@ -12,6 +12,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -18,7 +18,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     Remove-Item -Force nodejs-tmp; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath git; `
     Remove-Item -Force git.zip
 

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -17,6 +17,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Move-Item nodejs-tmp/node-v${env:NODE_VERSION}-win-x64 nodejs; `
     Remove-Item -Force node.zip; `
     Remove-Item -Force nodejs-tmp; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath git; `
     Remove-Item -Force git.zip

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -14,7 +14,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     Remove-Item -Force nodejs-tmp; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath git; `
     Remove-Item -Force git.zip
 

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -13,6 +13,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Move-Item nodejs-tmp/node-v${env:NODE_VERSION}-win-x64 nodejs; `
     Remove-Item -Force node.zip; `
     Remove-Item -Force nodejs-tmp; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath git; `
     Remove-Item -Force git.zip

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -16,7 +16,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -15,6 +15,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -13,6 +13,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force node.zip; `
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -14,7 +14,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     $env:PATH += \";${env:ProgramFiles}/nodejs\"; `
     & npm install -g gulp bower; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip -outfile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip -outfile git.zip; `
     Expand-Archive git.zip -DestinationPath $Env:ProgramFiles/git; `
     Remove-Item -Force git.zip
 


### PR DESCRIPTION
Fixes failures with this error:
```
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
```