### PR TITLE
Set RestoreUseSkipNonexistentTargets=false in the 2.0 image to workaround changes between the 2.1.4 and 2.1.101 SDK

### DIFF
--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -48,3 +48,8 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -26,3 +26,8 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -73,3 +73,8 @@ RUN dotnet restore C:\warmup\packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet `
     && del /F /S /Q C:\warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -47,3 +47,8 @@ RUN dotnet restore C:\warmup\packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet `
     && del /F /S /Q C:\warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -47,3 +47,8 @@ RUN dotnet restore C:/warmup/packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet; `
     Remove-Item -Recurse -Force C:/warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -32,3 +32,8 @@ RUN dotnet restore C:/warmup/packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet; `
     Remove-Item -Recurse -Force C:/warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -48,3 +48,8 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -26,3 +26,8 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false


### PR DESCRIPTION
Workaround https://github.com/Microsoft/DockerTools/issues/87.

Addresses #388 

FYI @glennc @nkolev92 @Eilon