### PR TITLE
Add Alpine runtime image and update to preview2

### DIFF
--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -44,6 +44,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 # warmup up NuGet package cache
 COPY packagescache.csproj C:/warmup/packagescache.csproj
 RUN dotnet restore C:/warmup/packagescache.csproj `
+        --source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json `
         --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet; `

--- a/2.1/alpine/amd64/runtime/Dockerfile
+++ b/2.1/alpine/amd64/runtime/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+
+# set up network
+ENV ASPNETCORE_URLS http://+:80
+
+# Workaround https://github.com/aspnet/libuv-package/issues/23
+# Install libuv globally and link it so coreclr can laod it
+RUN apk add --no-cache libuv \
+    && ln -s /usr/lib/libuv.so.1 /usr/lib/libuv.so
+
+# Install ASP.NET Core
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30338
+
+RUN apk add --no-cache --virtual .build-deps \
+        openssl \
+    && wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-alpine.3.6-x64.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
+    && rm aspnetcore.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && apk del .build-deps

--- a/2.1/bionic/amd64/runtime/Dockerfile
+++ b/2.1/bionic/amd64/runtime/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.0-preview1-final
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30338
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/2.1/bionic/amd64/sdk/Dockerfile
+++ b/2.1/bionic/amd64/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.1.300-preview1-sdk-bionic
+FROM microsoft/dotnet-nightly:2.1.300-preview2-sdk-bionic
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -15,11 +15,11 @@ RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-lin
 
 # Ensure packages required for standalone apps are pre-fetched
 
-# Set to ubuntu.16.04-x64 because preview1 doesn't yet support the ubuntu.18 RID
 RUN mkdir /tmp/warmup \
     && cd /tmp/warmup \
     && dotnet new web --no-restore \
-    && dotnet restore -p:RuntimeIdentifier=ubuntu.16.04-x64 \
+    && dotnet restore -p:RuntimeIdentifier=ubuntu.18.04-x64 \
+        --source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json \
         --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json \
         --source https://api.nuget.org/v3/index.json \
     && cd / \

--- a/2.1/nanoserver-1709/amd64/runtime/Dockerfile
+++ b/2.1/nanoserver-1709/amd64/runtime/Dockerfile
@@ -6,7 +6,7 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.0-preview1-final
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30338
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     Expand-Archive aspnetcore.zip -DestinationPath dotnet; `

--- a/2.1/nanoserver-1709/amd64/sdk/Dockerfile
+++ b/2.1/nanoserver-1709/amd64/sdk/Dockerfile
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
     Remove-Item -Force nodejs-tmp
 
 # Build image
-FROM microsoft/dotnet-nightly:2.1.300-preview1-sdk-nanoserver-1709
+FROM microsoft/dotnet-nightly:2.1.300-preview2-sdk-nanoserver-1709
 
 # Set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -40,6 +40,7 @@ RUN mkdir "%TEMP%/warmup" `
     && cd "%TEMP%/warmup" `
     && dotnet new web --no-restore `
     && dotnet restore -p:RuntimeIdentifier=win7-x64 `
+        --source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json `
         --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json `
         --source https://api.nuget.org/v3/index.json `
     && cd .. `

--- a/2.1/nanoserver-sac2016/amd64/runtime/Dockerfile
+++ b/2.1/nanoserver-sac2016/amd64/runtime/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV ASPNETCORE_URLS http://+:80
 
 # Retrieve ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.0-preview1-final
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30338
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     Expand-Archive aspnetcore.zip -DestinationPath  $Env:ProgramFiles\dotnet; `

--- a/2.1/nanoserver-sac2016/amd64/sdk/Dockerfile
+++ b/2.1/nanoserver-sac2016/amd64/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet-nightly:2.1.300-preview1-sdk-nanoserver-sac2016
+FROM microsoft/dotnet-nightly:2.1.300-preview2-sdk-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -27,6 +27,7 @@ RUN mkdir $env:TEMP\warmup; `
     cd $env:TEMP\warmup; `
     dotnet new web --no-restore; `
     dotnet restore -p:RuntimeIdentifier=win7-x64 `
+        --source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json `
         --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json `
         --source https://api.nuget.org/v3/index.json; `
     cd ..; `

--- a/2.1/stretch-slim/amd64/runtime/Dockerfile
+++ b/2.1/stretch-slim/amd64/runtime/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.0-preview1-final
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30338
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/2.1/stretch/amd64/sdk/Dockerfile
+++ b/2.1/stretch/amd64/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.1.300-preview1-sdk-stretch
+FROM microsoft/dotnet-nightly:2.1.300-preview2-sdk-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80
@@ -18,6 +18,7 @@ RUN mkdir /tmp/warmup \
     && cd /tmp/warmup \
     && dotnet new web --no-restore \
     && dotnet restore -p:RuntimeIdentifier=debian.8-x64 \
+        --source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json \
         --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json \
         --source https://api.nuget.org/v3/index.json \
     && cd / \

--- a/README.aspnetcore-build-nightly.md
+++ b/README.aspnetcore-build-nightly.md
@@ -6,22 +6,22 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 # Linux amd64 tags
 
-- [`1.1.6-1.1.7-jessie`, `1.1.6-1.1.7`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/sdk/Dockerfile)
-- [`2.0.5-2.1.4-stretch`, `2.0-stretch`, `2.0.5-2.1.4`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
-- [`2.0.5-2.1.4-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/sdk/Dockerfile)
-- [`2.1.300-preview1-bionic` (*2.1/bionic/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/bionic/amd64/sdk/Dockerfile)
-- [`2.1.300-preview1-stretch`, `2.1.300-preview1` (*2.1/stretch/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/stretch/amd64/sdk/Dockerfile)
+- [`1.1.7-1.1.8-jessie`, `1.1.7-1.1.8`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/sdk/Dockerfile)
+- [`2.0.6-2.1.101-stretch`, `2.0-stretch`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
+- [`2.0.6-2.1.101-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/sdk/Dockerfile)
+- [`2.1.300-preview2-bionic` (*2.1/bionic/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/bionic/amd64/sdk/Dockerfile)
+- [`2.1.300-preview2-stretch`, `2.1.300-preview2` (*2.1/stretch/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/stretch/amd64/sdk/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.5-2.1.4-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.5-2.1.4`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/sdk/Dockerfile)
-- [`2.1.300-preview1-nanoserver-1709`, `2.1.300-preview1` (*2.1/nanoserver-1709/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-1709/amd64/sdk/Dockerfile)
+- [`2.0.6-2.1.101-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.1.300-preview2-nanoserver-1709`, `2.1.300-preview2` (*2.1/nanoserver-1709/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-1709/amd64/sdk/Dockerfile)
 
 # Windows Server 2016 amd64 tags
 
-- [`1.1.6-1.1.7-nanoserver-sac2016`, `1.1.6-1.1.7`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.5-2.1.4-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.5-2.1.4`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.1.300-preview1-nanoserver-sac2016`, `2.1.300-preview1` (*2.1/nanoserver-sac2016/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-sac2016/amd64/sdk/Dockerfile)
+- [`1.1.7-1.1.8-nanoserver-sac2016`, `1.1.7-1.1.8`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.6-2.1.101-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.1.300-preview2-nanoserver-sac2016`, `2.1.300-preview2` (*2.1/nanoserver-sac2016/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-sac2016/amd64/sdk/Dockerfile)
 
 >**Note:** ASP.NET Core multi-arch tags, such as 2.0, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
 

--- a/README.aspnetcore-nightly.md
+++ b/README.aspnetcore-nightly.md
@@ -10,24 +10,25 @@ These images contain the runtime only. Use [`microsoft/aspnetcore-build-nightly`
 
 # Linux amd64 tags
 
-- [`1.0.9-jessie`, `1.0.9`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/jessie/runtime/Dockerfile)
-- [`1.1.6-jessie`, `1.1.6`, `1.1`, `1` (*1.1/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/runtime/Dockerfile)
-- [`2.0.5-stretch`, `2.0-stretch`, `2.0.5`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
-- [`2.0.5-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/runtime/Dockerfile)
-- [`2.1.0-preview1-bionic` (*2.1/bionic/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/bionic/amd64/runtime/Dockerfile)
-- [`2.1.0-preview1-stretch-slim`, `2.1.0-preview1` (*2.1/stretch-slim/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/stretch-slim/amd64/runtime/Dockerfile)
+- [`1.0.10-jessie`, `1.0.10`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/jessie/runtime/Dockerfile)
+- [`1.1.7-jessie`, `1.1.7`, `1.1`, `1` (*1.1/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/runtime/Dockerfile)
+- [`2.0.6-stretch`, `2.0-stretch`, `2.0.6`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
+- [`2.0.6-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/runtime/Dockerfile)
+- [`2.1.0-preview2-alpine` (*2.1/alpine/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/alpine/amd64/runtime/Dockerfile)
+- [`2.1.0-preview2-bionic` (*2.1/bionic/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/bionic/amd64/runtime/Dockerfile)
+- [`2.1.0-preview2-stretch-slim`, `2.1.0-preview2` (*2.1/stretch-slim/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/stretch-slim/amd64/runtime/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.5-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.5`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/runtime/Dockerfile)
-- [`2.1.0-preview1-nanoserver-1709`, `2.1.0-preview1` (*2.1/nanoserver-1709/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-1709/amd64/runtime/Dockerfile)
+- [`2.0.6-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.6`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/runtime/Dockerfile)
+- [`2.1.0-preview2-nanoserver-1709`, `2.1.0-preview2` (*2.1/nanoserver-1709/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-1709/amd64/runtime/Dockerfile)
 
 # Windows Server 2016 amd64 tags
 
-- [`1.0.9-nanoserver-sac2016`, `1.0.9`, `1.0` (*1.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/nanoserver-sac2016/runtime/Dockerfile)
-- [`1.1.6-nanoserver-sac2016`, `1.1.6`, `1.1`, `1` (*1.1/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/runtime/Dockerfile)
-- [`2.0.5-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.5`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/runtime/Dockerfile)
-- [`2.1.0-preview1-nanoserver-sac2016`, `2.1.0-preview1` (*2.1/nanoserver-sac2016/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-sac2016/amd64/runtime/Dockerfile)
+- [`1.0.10-nanoserver-sac2016`, `1.0.10`, `1.0` (*1.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/nanoserver-sac2016/runtime/Dockerfile)
+- [`1.1.7-nanoserver-sac2016`, `1.1.7`, `1.1`, `1` (*1.1/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/runtime/Dockerfile)
+- [`2.0.6-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.6`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/runtime/Dockerfile)
+- [`2.1.0-preview2-nanoserver-sac2016`, `2.1.0-preview2` (*2.1/nanoserver-sac2016/amd64/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.1/nanoserver-sac2016/amd64/runtime/Dockerfile)
 
 >**Note:** ASP.NET Core multi-arch tags, such as 2.0, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
 

--- a/manifest.json
+++ b/manifest.json
@@ -115,31 +115,42 @@
         {
           "platforms": [
             {
+              "dockerfile": "2.1/alpine/amd64/runtime",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview2-alpine": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "2.1/bionic/amd64/runtime",
               "os": "linux",
               "tags": {
-                "2.1.0-preview1-bionic": {}
+                "2.1.0-preview2-bionic": {}
               }
             }
           ]
         },
         {
           "sharedTags": {
-            "2.1.0-preview1": {}
+            "2.1.0-preview2": {}
           },
           "platforms": [
             {
               "dockerfile": "2.1/stretch-slim/amd64/runtime",
               "os": "linux",
               "tags": {
-                "2.1.0-preview1-stretch-slim": {}
+                "2.1.0-preview2-stretch-slim": {}
               }
             },
             {
               "dockerfile": "2.1/nanoserver-sac2016/amd64/runtime",
               "os": "windows",
               "tags": {
-                "2.1.0-preview1-nanoserver-sac2016": {}
+                "2.1.0-preview2-nanoserver-sac2016": {}
               }
             },
             {
@@ -147,7 +158,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.1.0-preview1-nanoserver-1709": {}
+                "2.1.0-preview2-nanoserver-1709": {}
               }
             }
           ]
@@ -244,28 +255,28 @@
               "dockerfile": "2.1/bionic/amd64/sdk",
               "os": "linux",
               "tags": {
-                "2.1.300-preview1-bionic": {}
+                "2.1.300-preview2-bionic": {}
               }
             }
           ]
         },
         {
           "sharedTags": {
-            "2.1.300-preview1": {}
+            "2.1.300-preview2": {}
           },
           "platforms": [
             {
               "dockerfile": "2.1/stretch/amd64/sdk",
               "os": "linux",
               "tags": {
-                "2.1.300-preview1-stretch": {}
+                "2.1.300-preview2-stretch": {}
               }
             },
             {
               "dockerfile": "2.1/nanoserver-sac2016/amd64/sdk",
               "os": "windows",
               "tags": {
-                "2.1.300-preview1-nanoserver-sac2016": {}
+                "2.1.300-preview2-nanoserver-sac2016": {}
               }
             },
             {
@@ -273,7 +284,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.1.300-preview1-nanoserver-1709": {}
+                "2.1.300-preview2-nanoserver-1709": {}
               }
             }
           ]

--- a/test.ps1
+++ b/test.ps1
@@ -48,8 +48,7 @@ function Get-TestRid($tagName) {
     }
     else {
         if ($tagName -like '*bionic*') {
-            # Return ubuntu 16 because ubuntu 18 is not supported in the RID graph as of 2.1.0-preview1
-            return "ubuntu.16.04-x64"
+            return "ubuntu.18.04-x64"
         }
         else {
             return "debian.8-x64"


### PR DESCRIPTION
 - Add 2.1.0-preview2-alpine runtime image. Resolves https://github.com/aspnet/aspnet-docker/issues/381
 - Update to aspnetcore 2.1.0-preview2-30338
 - Update SDK images to 2.1.300-preview2