### PR TITLE
Update SDK to 2.1.104

### DIFF
--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-jessie
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/jessie/kitchensink/Dockerfile
+++ b/2.0/jessie/kitchensink/Dockerfile
@@ -48,8 +48,3 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-jessie
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-jessie
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/jessie/sdk/Dockerfile
+++ b/2.0/jessie/sdk/Dockerfile
@@ -26,8 +26,3 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -74,7 +74,3 @@ RUN dotnet restore C:\warmup\packagescache.csproj `
         --verbosity quiet `
     && del /F /S /Q C:\warmup
 
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-1709/kitchensink/Dockerfile
+++ b/2.0/nanoserver-1709/kitchensink/Dockerfile
@@ -45,7 +45,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://distaspnet.blob.core.windows.net/
 
 
 # Kitchen Sink image
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-nanoserver-1709
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-nanoserver-1709
 
 # Note: Kitchen Sink image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -47,8 +47,3 @@ RUN dotnet restore C:\warmup\packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet `
     && del /F /S /Q C:\warmup
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-1709/sdk/Dockerfile
+++ b/2.0/nanoserver-1709/sdk/Dockerfile
@@ -26,7 +26,7 @@ RUN Invoke-WebRequest -UseBasicParsing https://nodejs.org/dist/v${env:NODE_VERSI
 
 
 # Build image
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-nanoserver-1709
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-nanoserver-1709
 
 # Note: Build image's SHELL is the CMD shell (different than the installer image).
 

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/nanoserver-sac2016/kitchensink/Dockerfile
+++ b/2.0/nanoserver-sac2016/kitchensink/Dockerfile
@@ -47,8 +47,3 @@ RUN dotnet restore C:/warmup/packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet; `
     Remove-Item -Recurse -Force C:/warmup
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -32,8 +32,3 @@ RUN dotnet restore C:/warmup/packagescache.csproj `
         --source https://api.nuget.org/v3/index.json `
         --verbosity quiet; `
     Remove-Item -Recurse -Force C:/warmup
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/nanoserver-sac2016/sdk/Dockerfile
+++ b/2.0/nanoserver-sac2016/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-nanoserver-sac2016
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-nanoserver-sac2016
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-stretch
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/2.0/stretch/kitchensink/Dockerfile
+++ b/2.0/stretch/kitchensink/Dockerfile
@@ -48,8 +48,3 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -26,8 +26,3 @@ RUN dotnet restore /tmp/warmup/packagescache.csproj \
     && rm -rf /tmp/warmup/
 
 WORKDIR /
-
-# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
-# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
-# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
-ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/stretch/sdk/Dockerfile
+++ b/2.0/stretch/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.6-sdk-2.1.101-stretch
+FROM microsoft/dotnet:2.0.6-sdk-2.1.104-stretch
 
 # set up environment
 ENV ASPNETCORE_URLS http://+:80

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -7,8 +7,8 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 # Supported Linux amd64 tags
 
 - [`1.1.7-1.1.8-jessie`, `1.1.7-1.1.8`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`2.0.6-2.1.101-stretch`, `2.0-stretch`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
-- [`2.0.6-2.1.101-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- [`2.0.6-2.1.104-stretch`, `2.0-stretch`, `2.0.6-2.1.104`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.6-2.1.104-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
 - [`2.1.300-preview1-bionic` (*2.1/bionic/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.1/bionic/amd64/sdk/Dockerfile)
 - [`2.1.300-preview1-stretch`, `2.1.300-preview1` (*2.1/stretch/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.1/stretch/amd64/sdk/Dockerfile)
 - [`1.0-1.1-jessie`, `1.0-1.1` (*1.1/jessie/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/kitchensink/Dockerfile)
@@ -17,13 +17,13 @@ This repository contains images that are used to compile/publish ASP.NET Core ap
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`2.0.6-2.1.101-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.0.6-2.1.104-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.6-2.1.104`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
 - [`2.1.300-preview1-nanoserver-1709`, `2.1.300-preview1` (*2.1/nanoserver-1709/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.1/nanoserver-1709/amd64/sdk/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
 - [`1.1.7-1.1.8-nanoserver-sac2016`, `1.1.7-1.1.8`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.6-2.1.101-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.6-2.1.101`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.6-2.1.104-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.6-2.1.104`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
 - [`2.1.300-preview1-nanoserver-sac2016`, `2.1.300-preview1` (*2.1/nanoserver-sac2016/amd64/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.1/nanoserver-sac2016/amd64/sdk/Dockerfile)
 - [`1.0-1.1-nanoserver-sac2016`, `1.0-1.1` (*1.1/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/kitchensink/Dockerfile)
 - [`1.0-2.0-nanoserver-sac2016`, `1.0-2.0` (*2.0/nanoserver-sac2016/kitchensink/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/kitchensink/Dockerfile)

--- a/manifest.json
+++ b/manifest.json
@@ -189,7 +189,7 @@
         },
         {
           "sharedTags": {
-            "2.0.6-2.1.101": {},
+            "2.0.6-2.1.104": {},
             "2.0": {},
             "2": {},
             "latest": {}
@@ -199,7 +199,7 @@
               "dockerfile": "2.0/stretch/sdk",
               "os": "linux",
               "tags": {
-                "2.0.6-2.1.101-stretch": {},
+                "2.0.6-2.1.104-stretch": {},
                 "2.0-stretch": {}
               }
             },
@@ -207,7 +207,7 @@
               "dockerfile": "2.0/nanoserver-sac2016/sdk",
               "os": "windows",
               "tags": {
-                "2.0.6-2.1.101-nanoserver-sac2016": {},
+                "2.0.6-2.1.104-nanoserver-sac2016": {},
                 "2.0-nanoserver-sac2016": {},
                 "2.0-nanoserver": {
                   "isUndocumented": true
@@ -219,7 +219,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.0.6-2.1.101-nanoserver-1709": {},
+                "2.0.6-2.1.104-nanoserver-1709": {},
                 "2.0-nanoserver-1709": {}
               }
             }
@@ -231,7 +231,7 @@
               "dockerfile": "2.0/jessie/sdk",
               "os": "linux",
               "tags": {
-                "2.0.6-2.1.101-jessie": {},
+                "2.0.6-2.1.104-jessie": {},
                 "2.0-jessie": {},
                 "2-jessie": {}
               }

--- a/test.ps1
+++ b/test.ps1
@@ -175,7 +175,7 @@ try {
                     # map the 1.1.5-1.1.6 sdk tags to the runtime tag name
                     "1.1" { $sdk_tag -replace '-1.1.8', '' }
                     # map the 2.0.4-2.1.3 sdk tags to the runtime tag name
-                    "2.0" { $sdk_tag -replace '-2.1.101', '' }
+                    "2.0" { $sdk_tag -replace '-2.1.104', '' }
                     # map the 2.1.300 sdk tags to the runtime tag name
                     "2.1" { $sdk_tag -replace '2.1.300', '2.1.0' }
                     Default { $sdk_tag }


### PR DESCRIPTION
Changes:
 - update to 2.1.104 SDK (base was updated in https://github.com/dotnet/dotnet-docker/pull/464)
 - Remove workaround for Microsoft/DockerTools#87 which was added to base image in https://github.com/dotnet/dotnet-docker/pull/430