### PR TITLE
Update README 

### DIFF
--- a/2.1/README.md
+++ b/2.1/README.md
@@ -3,9 +3,7 @@ HTTP 301 Moved Permanently
 
 **Where are the 2.1 aspnet-docker images?**
 
-In 2.1\*, the ASP.NET Core Docker images have migrated to https://github.com/dotnet/dotnet-docker.
-
-_\*Note: ASP.NET Core 2.1 is still in preview._
+In 2.1, the ASP.NET Core Docker images have migrated to https://github.com/dotnet/dotnet-docker.
 
 **How can I upgrade from 1.x/2.0 to 2.1?**
 
@@ -18,7 +16,7 @@ Current | Upgrade
 
 **I was using NodeJS in `microsoft/aspnetcore-build`, but this is missing from `microsoft/dotnet:2.1-sdk`. What should I do?**
 
-You can either install NodeJS by adding a few lines of code to your Dockerfile that download and extract NodeJS, 
+You can either install NodeJS by adding a few lines of code to your Dockerfile that download and extract NodeJS,
 or you can use the multi-stage feature of Docker and the official NodeJS images.
 
 Sample code to install NodeJS on your own:

--- a/README.aspnetcore-build-nightly.md
+++ b/README.aspnetcore-build-nightly.md
@@ -4,20 +4,27 @@ ASP.NET Core Build Docker Image (Nightly)
 
 This repository contains images that are used to compile/publish ASP.NET Core applications inside the container. This is different to compiling an ASP.NET Core application and then adding the compiled output to an image, which is what you would do when using the [microsoft/aspnetcore-nightly](https://hub.docker.com/r/microsoft/aspnetcore-nightly/) image. These Dockerfiles use the [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) image as its base.
 
+Latest images for **2.1** and newer are now available on [microsoft/dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/). See [this link][migrate] for more details about migrating to 2.1.
+
+[migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
+
 # Linux amd64 tags
 
 - [`1.1.8-1.1.9-jessie`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/sdk/Dockerfile)
-- [`2.0.7-2.1.105-stretch`, `2.0-stretch`, `2.0.7-2.1.105`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
+- [`2.0.7-2.1.105-stretch`, `2.0-stretch`, `2.0.7-2.1.105`, `2.0`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/sdk/Dockerfile)
 - [`2.0.7-2.1.105-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.7-2.1.105-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.7-2.1.105`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.0.7-2.1.105-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.7-2.1.105`, `2.0`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 # Windows Server 2016 amd64 tags
 
 - [`1.1.8-1.1.9-nanoserver-sac2016`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.7-2.1.105-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.7-2.1.105`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.7-2.1.105-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.7-2.1.105`, `2.0`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 >**Note:** In images tagged with two versions in this pattern `A.B.C-X.Y.Z`, the first version `A.B.C` represents the .NET Core runtime version, and the second `X.Y.Z` represents the .NET Core SDK version.
 
@@ -35,8 +42,7 @@ This image contains:
 
 # Related images
 
-1. [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) - the .NET Core image if you don't need the ASP.NET Core specific optimizations.
-2. [microsoft/aspnetcore-nightly](https://hub.docker.com/r/microsoft/aspnetcore-nightly/) - the ASP.NET Core runtime image, for when you don't need to build inside a container.
+* [microsoft/aspnetcore-nightly](https://hub.docker.com/r/microsoft/aspnetcore-nightly/) - the ASP.NET Core runtime image, for when you don't need to build inside a container.
 
 # Example Usage
 

--- a/README.aspnetcore-build-nightly.md
+++ b/README.aspnetcore-build-nightly.md
@@ -8,6 +8,8 @@ Latest images for **2.1** and newer are now available on [microsoft/dotnet-night
 
 [migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
+The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET Core and Docker together. See [Building Docker Images for .NET Core Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
 # Linux amd64 tags
 
 - [`1.1.8-1.1.9-jessie`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/sdk/Dockerfile)

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -8,6 +8,8 @@ Latest images for **2.1** and newer are now available on [microsoft/dotnet](http
 
 [migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
+The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET Core and Docker together. See [Building Docker Images for .NET Core Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
 # Linux amd64 tags
 
 - [`1.1.8-1.1.9-jessie`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)

--- a/README.aspnetcore-build.md
+++ b/README.aspnetcore-build.md
@@ -4,24 +4,32 @@ ASP.NET Core Build Docker Image
 
 This repository contains images that are used to compile/publish ASP.NET Core applications inside the container. This is different to compiling an ASP.NET Core application and then adding the compiled output to an image, which is what you would do when using the [microsoft/aspnetcore](https://hub.docker.com/r/microsoft/aspnetcore/) image. These Dockerfiles use the [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) image as its base.
 
+Latest images for **2.1** and newer are now available on [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/). See [this link][migrate] for more details about migrating to 2.1.
+
+[migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
+
 # Linux amd64 tags
 
 - [`1.1.8-1.1.9-jessie`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/sdk/Dockerfile)
-- [`2.0.8-2.1.200-stretch`, `2.0-stretch`, `2.0.8-2.1.200`, `2.0`, `2`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
+- [`2.0.8-2.1.200-stretch`, `2.0-stretch`, `2.0.8-2.1.200`, `2.0`, `latest` (*2.0/stretch/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/sdk/Dockerfile)
 - [`2.0.8-2.1.200-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.0.8-2.1.200-nanoserver-1803`, `2.0-nanoserver-1803`, `2.0.8-2.1.200`, `2.0`, `2`, `latest` (*2.0/nanoserver-1803/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1803/sdk/Dockerfile)
+- [`2.0.8-2.1.200-nanoserver-1803`, `2.0-nanoserver-1803`, `2.0.8-2.1.200`, `2.0`, `latest` (*2.0/nanoserver-1803/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1803/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.8-2.1.200-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.8-2.1.200`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
+- [`2.0.8-2.1.200-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.8-2.1.200`, `2.0`, `latest` (*2.0/nanoserver-1709/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server 2016 amd64 tags
 
 - [`1.1.8-1.1.9-nanoserver-sac2016`, `1.1.8-1.1.9`, `1.1`, `1` (*1.1/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/sdk/Dockerfile)
-- [`2.0.8-2.1.200-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.8-2.1.200`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- [`2.0.8-2.1.200-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.8-2.1.200`, `2.0`, `latest` (*2.0/nanoserver-sac2016/sdk/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/sdk/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 >**Note:** In images tagged with two versions in this pattern `A.B.C-X.Y.Z`, the first version `A.B.C` represents the .NET Core runtime version, and the second `X.Y.Z` represents the .NET Core SDK version.
 
@@ -39,8 +47,7 @@ This image contains:
 
 # Related images
 
-1. [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) - the .NET Core image if you don't need the ASP.NET Core specific optimizations.
-2. [microsoft/aspnetcore](https://hub.docker.com/r/microsoft/aspnetcore/) - the ASP.NET Core runtime image, for when you don't need to build inside a container.
+* [microsoft/aspnetcore](https://hub.docker.com/r/microsoft/aspnetcore/) - the ASP.NET Core runtime image, for when you don't need to build inside a container.
 
 # Example Usage
 

--- a/README.aspnetcore-nightly.md
+++ b/README.aspnetcore-nightly.md
@@ -8,6 +8,8 @@ Latest images for **2.1** and newer are now available on [microsoft/dotnet-night
 
 [migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
+The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET Core and Docker together. See [Building Docker Images for .NET Core Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
 # Linux amd64 tags
 
 - [`1.0.11-jessie`, `1.0.11`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/jessie/runtime/Dockerfile)

--- a/README.aspnetcore-nightly.md
+++ b/README.aspnetcore-nightly.md
@@ -2,28 +2,31 @@
 ASP.NET Core Runtime Docker Image (Nightly)
 ===========================================
 
-This repository contains images for running published ASP.NET Core applications. These images use the
-[microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) image as its base.
+This repository contains images for running published ASP.NET Core applications. These images contain the runtime only. Use [`microsoft/aspnetcore-build-nightly`](https://hub.docker.com/r/microsoft/aspnetcore-build-nightly/) to build ASP.NET Core apps inside the container.
 
-These images contain the runtime only. Use [`microsoft/aspnetcore-build-nightly`](https://hub.docker.com/r/microsoft/aspnetcore-build-nightly/) to build ASP.NET Core apps inside the container.
+Latest images for **2.1** and newer are now available on [microsoft/dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/). See [this link][migrate] for more details about migrating to 2.1.
 
+[migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
 # Linux amd64 tags
 
 - [`1.0.11-jessie`, `1.0.11`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/jessie/runtime/Dockerfile)
 - [`1.1.8-jessie`, `1.1.8`, `1.1`, `1` (*1.1/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/jessie/runtime/Dockerfile)
-- [`2.0.7-stretch`, `2.0-stretch`, `2.0.7`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
+- [`2.0.7-stretch`, `2.0-stretch`, `2.0.7`, `2.0`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/stretch/runtime/Dockerfile)
 - [`2.0.7-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/jessie/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.7-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.7`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/runtime/Dockerfile)
+- [`2.0.7-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.7`, `2.0`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-1709/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 # Windows Server 2016 amd64 tags
 
 - [`1.0.11-nanoserver-sac2016`, `1.0.11`, `1.0` (*1.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.0/nanoserver-sac2016/runtime/Dockerfile)
 - [`1.1.8-nanoserver-sac2016`, `1.1.8`, `1.1`, `1` (*1.1/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/1.1/nanoserver-sac2016/runtime/Dockerfile)
-- [`2.0.7-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.7`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/runtime/Dockerfile)
+- [`2.0.7-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.7`, `2.0`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/dev/2.0/nanoserver-sac2016/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet-nightly][migrate].
 
 # What is ASP.NET Core?
 
@@ -40,8 +43,7 @@ This image contains:
 
 # Related images
 
-1. [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) - the .NET Core image if you don't need the ASP.NET Core specific optimizations.
-2. [microsoft/aspnetcore-build-nightly](https://hub.docker.com/r/microsoft/aspnetcore-build-nightly/) - The ASP.NET Core build image for publishing an ASP.NET Core app inside a container.
+* [microsoft/aspnetcore-build-nightly](https://hub.docker.com/r/microsoft/aspnetcore-build-nightly/) - The ASP.NET Core build image for publishing an ASP.NET Core app inside a container.
 
 # How to use this image
 

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -2,32 +2,36 @@
 ASP.NET Core Runtime Docker Image
 =================================
 
-This repository contains images for running published ASP.NET Core applications. These images use the
-[microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) image as its base.
+This repository contains images for running published ASP.NET Core applications. These images contain the runtime only. Use [`microsoft/aspnetcore-build`](https://hub.docker.com/r/microsoft/aspnetcore-build/) to build ASP.NET Core apps inside the container.
 
-These images contain the runtime only. Use [`microsoft/aspnetcore-build`](https://hub.docker.com/r/microsoft/aspnetcore-build/) to build ASP.NET Core apps inside the container.
+Latest images for **2.1** and newer are now available on [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/). See [this link][migrate] for more details about migrating to 2.1.
 
+[migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
 # Linux amd64 tags
 
 - [`1.0.11-jessie`, `1.0.11`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)
 - [`1.1.8-jessie`, `1.1.8`, `1.1`, `1` (*1.1/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/jessie/runtime/Dockerfile)
-- [`2.0.8-stretch`, `2.0-stretch`, `2.0.8`, `2.0`, `2`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/runtime/Dockerfile)
+- [`2.0.8-stretch`, `2.0-stretch`, `2.0.8`, `2.0`, `latest` (*2.0/stretch/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/stretch/runtime/Dockerfile)
 - [`2.0.8-jessie`, `2.0-jessie`, `2-jessie` (*2.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/jessie/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.0.8-nanoserver-1803`, `2.0-nanoserver-1803`, `2.0.8`, `2.0`, `2`, `latest` (*2.0/nanoserver-1803/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1803/runtime/Dockerfile)
+- [`2.0.8-nanoserver-1803`, `2.0-nanoserver-1803`, `2.0.8`, `2.0`, `latest` (*2.0/nanoserver-1803/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1803/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.0.8-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.8`, `2.0`, `2`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/runtime/Dockerfile)
+- [`2.0.8-nanoserver-1709`, `2.0-nanoserver-1709`, `2.0.8`, `2.0`, `latest` (*2.0/nanoserver-1709/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-1709/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # Windows Server 2016 amd64 tags
 
 - [`1.0.11-nanoserver-sac2016`, `1.0.11`, `1.0` (*1.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/nanoserver-sac2016/runtime/Dockerfile)
 - [`1.1.8-nanoserver-sac2016`, `1.1.8`, `1.1`, `1` (*1.1/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.1/nanoserver-sac2016/runtime/Dockerfile)
 - [`2.0.8-nanoserver-sac2016`, `2.0-nanoserver-sac2016`, `2.0.8`, `2.0`, `2`, `latest` (*2.0/nanoserver-sac2016/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/2.0/nanoserver-sac2016/runtime/Dockerfile)
+- For 2.1 and up, use [microsoft/dotnet][migrate].
 
 # What is ASP.NET Core?
 
@@ -44,8 +48,7 @@ This image contains:
 
 # Related images
 
-1. [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) - the .NET Core image if you don't need the ASP.NET Core specific optimizations.
-2. [microsoft/aspnetcore-build](https://hub.docker.com/r/microsoft/aspnetcore-build/) - The ASP.NET Core build image for publishing an ASP.NET Core app inside a container.
+* [microsoft/aspnetcore-build](https://hub.docker.com/r/microsoft/aspnetcore-build/) - The ASP.NET Core build image for publishing an ASP.NET Core app inside a container.
 
 # How to use this image
 

--- a/README.aspnetcore.md
+++ b/README.aspnetcore.md
@@ -8,6 +8,9 @@ Latest images for **2.1** and newer are now available on [microsoft/dotnet](http
 
 [migrate]: https://github.com/aspnet/aspnet-docker/blob/master/2.1
 
+The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET Core and Docker together. See [Building Docker Images for .NET Core Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+
 # Linux amd64 tags
 
 - [`1.0.11-jessie`, `1.0.11`, `1.0` (*1.0/jessie/runtime/Dockerfile*)](https://github.com/aspnet/aspnet-docker/blob/master/1.0/jessie/runtime/Dockerfile)

--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,9 @@
           "sharedTags": {
             "2.0.8": {},
             "2.0": {},
-            "2": {},
+            "2": {
+              "isUndocumented": true
+            },
             "latest": {}
           },
           "platforms": [
@@ -160,7 +162,9 @@
           "sharedTags": {
             "2.0.8-2.1.200": {},
             "2.0": {},
-            "2": {},
+            "2": {
+              "isUndocumented": true
+            },
             "latest": {}
           },
           "platforms": [


### PR DESCRIPTION
Changes:

* Make `2` an "undocumented" tag (following what microsoft/dotnet)
* Add links to `microsoft/dotnet` for 2.1 images
* Update explanation of the migration to 2.1

cc @glennc 