### PR TITLE
Add missing space to checksum string

### DIFF
--- a/2.1/README.md
+++ b/2.1/README.md
@@ -26,7 +26,7 @@ Sample code to install NodeJS on your own:
 ENV NODE_VERSION 8.9.4
 ENV NODE_DOWNLOAD_SHA 21fb4690e349f82d708ae766def01d7fec1b085ce1f5ab30d9bda8ee126ca8fc
 RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" --output nodejs.tar.gz \
-    && echo "$NODE_DOWNLOAD_SHA nodejs.tar.gz" | sha256sum -c - \
+    && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -cw - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \
     && rm nodejs.tar.gz \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs


### PR DESCRIPTION
1. Added the missing space to the [checksum string](https://nodejs.org/dist/v8.9.4/SHASUMS256.txt) for the check to pass.
2. Add `w` flag to `sha256sum` so that user is warned if a formatting issue (like the missing space) occurs again in the future.
